### PR TITLE
Complain loudly about unhandled arguments

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -337,6 +337,11 @@ int main_(int argc, char* const* argv)
     argc -= optind;
     argv += optind;
 
+    if (argc != 0) {
+        cerr << "Unhandled arg: " << argv[0] << endl;
+        return 1;
+    }
+
     if (inFile.empty()) {
         cerr << "No input file" << endl;
         return 1;


### PR DESCRIPTION
I spent some time today figuring out why I can't use the ATRAC3-format files encoded with the tool.

Turns out the [problem existed between keyboard and chair](https://en.wiktionary.org/wiki/PEBKAC):

I used this command line (based also on the `--help` output, this looked sane):

```
build/src/atracdenc --encode atrac3 -i somefile.wav -o somefile.oma
```

Turns out, this doesn't work and encodes as ATRAC1 instead, as `--encode` is parsed without any argument, and `atrac3` is handled separately (silently ignored). It's a combination of [`getopt_long()`](https://linux.die.net/man/3/getopt_long) and the optional parameter handling.

This does work, however:

```
build/src/atracdenc --encode=atrac3 -i somefile.wav -o somefile.oma
```

Proposed "quick fix" that will complain like this for the first command line:

```
Unhandled arg: atrac3
```
