### PR TITLE
Fix CMake build file generation error and add a missing <cstdint> header

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,12 +23,14 @@ function(enable_cxx_compiler_flag_if_supported flag)
     endif()
 endfunction()
 
-enable_cxx_compiler_flag_if_supported("-Wall")
-enable_cxx_compiler_flag_if_supported("-Wextra")
 
-project(atracdenc)
+
+project("atracdenc" CXX C)
 
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules")
+
+enable_cxx_compiler_flag_if_supported("-Wall")
+enable_cxx_compiler_flag_if_supported("-Wextra")
 
 if (WIN32)
     add_compile_definitions(PLATFORM_WINDOWS)
@@ -100,4 +102,3 @@ set(SOURCE_EXE
 add_executable(atracdenc ${SOURCE_EXE})
 target_link_libraries(atracdenc pcm_io oma atracdenc_impl ${SNDFILE_LIBRARIES})
 install(TARGETS atracdenc)
-

--- a/src/bitstream/bitstream.cpp
+++ b/src/bitstream/bitstream.cpp
@@ -15,7 +15,7 @@
  * License along with AtracDEnc; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-
+#include <cstdint>
 #include "bitstream.h"
 
 #ifndef BIGENDIAN_ORDER


### PR DESCRIPTION
This pull request fixes the following CMake error, except for the deprecation warning.
```
CMake Deprecation Warning at CMakeLists.txt:1 (CMAKE_MINIMUM_REQUIRED):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


CMake Error at /usr/share/cmake/Modules/Internal/CheckFlagCommonConfig.cmake:61 (message):
  check_compiler_flag: CXX: needs to be enabled before use.
Call Stack (most recent call first):
  /usr/share/cmake/Modules/Internal/CheckCompilerFlag.cmake:13 (cmake_check_flag_common_init)
  /usr/share/cmake/Modules/CheckCXXCompilerFlag.cmake:34 (cmake_check_compiler_flag)
  CMakeLists.txt:18 (check_cxx_compiler_flag)
  CMakeLists.txt:26 (enable_cxx_compiler_flag_if_supported)


CMake Error at /usr/share/cmake/Modules/Internal/CheckFlagCommonConfig.cmake:61 (message):
  check_compiler_flag: CXX: needs to be enabled before use.
Call Stack (most recent call first):
  /usr/share/cmake/Modules/Internal/CheckCompilerFlag.cmake:13 (cmake_check_flag_common_init)
  /usr/share/cmake/Modules/CheckCXXCompilerFlag.cmake:34 (cmake_check_compiler_flag)
  CMakeLists.txt:18 (check_cxx_compiler_flag)
  CMakeLists.txt:27 (enable_cxx_compiler_flag_if_supported)


-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found LIBSNDFILE: /usr/include
-- Configuring incomplete, errors occurred!
```
By the way, the original ```bitstream/bitstream.cpp``` file was missing ```<cstdint>``` header.