### PR TITLE
Clean qmf code.

### DIFF
--- a/src/atrac/atrac1_qmf.h
+++ b/src/atrac/atrac1_qmf.h
@@ -22,20 +22,19 @@
 
 namespace NAtracDEnc {
 
-template<class TIn>
 class Atrac1AnalysisFilterBank {
     const static int nInSamples = 512;
     const static int delayComp = 39;
-    TQmf<TIn, nInSamples> Qmf1;
-    TQmf<TIn, nInSamples / 2> Qmf2;
+    TQmf<nInSamples> Qmf1;
+    TQmf<nInSamples / 2> Qmf2;
     std::vector<float> MidLowTmp;
     std::vector<float> DelayBuf;
 public:
-    Atrac1AnalysisFilterBank() {
+    Atrac1AnalysisFilterBank() noexcept {
         MidLowTmp.resize(512);
         DelayBuf.resize(delayComp + 512);
     }
-    void Analysis(TIn* pcm, float* low, float* mid, float* hi) {
+    void Analysis(const float* pcm, float* low, float* mid, float* hi) noexcept {
         memcpy(&DelayBuf[0], &DelayBuf[256], sizeof(float) *  delayComp);
         Qmf1.Analysis(pcm, &MidLowTmp[0], &DelayBuf[delayComp]);
         Qmf2.Analysis(&MidLowTmp[0], low, mid);
@@ -43,20 +42,20 @@ public:
 
     }
 };
-template<class TOut>
+
 class Atrac1SynthesisFilterBank {
     const static int nInSamples = 512;
     const static int delayComp = 39;
-    TQmf<TOut, nInSamples> Qmf1;
-    TQmf<TOut, nInSamples / 2> Qmf2;
+    TQmf<nInSamples> Qmf1;
+    TQmf<nInSamples / 2> Qmf2;
     std::vector<float> MidLowTmp;
     std::vector<float> DelayBuf;
 public:
-    Atrac1SynthesisFilterBank() {
+    Atrac1SynthesisFilterBank() noexcept {
         MidLowTmp.resize(512);
         DelayBuf.resize(delayComp + 512);
     }
-    void Synthesis(TOut* pcm, float* low, float* mid, float* hi) {
+    void Synthesis(float* pcm, const float* low, const float* mid, const float* hi) noexcept {
         memcpy(&DelayBuf[0], &DelayBuf[256], sizeof(float) *  delayComp);
         memcpy(&DelayBuf[delayComp], hi, sizeof(float) * 256);
         Qmf2.Synthesis(&MidLowTmp[0], &low[0], &mid[0]);

--- a/src/atrac/atrac3_qmf.h
+++ b/src/atrac/atrac3_qmf.h
@@ -22,20 +22,19 @@
 
 namespace NAtracDEnc {
 
-template<class TIn>
 class Atrac3AnalysisFilterBank {
     const static int nInSamples = 1024;
-    TQmf<TIn, nInSamples> Qmf1;
-    TQmf<TIn, nInSamples / 2> Qmf2;
-    TQmf<TIn, nInSamples / 2> Qmf3;
+    TQmf<nInSamples> Qmf1;
+    TQmf<nInSamples / 2> Qmf2;
+    TQmf<nInSamples / 2> Qmf3;
     std::vector<float> Buf1;
     std::vector<float> Buf2;
 public:
-    Atrac3AnalysisFilterBank() {
+    Atrac3AnalysisFilterBank() noexcept {
         Buf1.resize(nInSamples);
         Buf2.resize(nInSamples);
     }
-    void Analysis(TIn* pcm, float* subs[4]) {
+    void Analysis(const float* pcm, float* subs[4]) noexcept {
         Qmf1.Analysis(pcm, Buf1.data(), Buf2.data());
         Qmf2.Analysis(Buf1.data(), subs[0], subs[1]);
         Qmf3.Analysis(Buf2.data(), subs[3], subs[2]);

--- a/src/atrac1denc.h
+++ b/src/atrac1denc.h
@@ -63,7 +63,7 @@ class TAtrac1Encoder : public IProcessor, public TAtrac1MDCT {
     std::array<std::array<float, 256 + 16>, 2> PcmBufMid;
     std::array<std::array<float, 512 + 16>, 2> PcmBufHi;
 
-    Atrac1AnalysisFilterBank<float> AnalysisFilterBank[2];
+    Atrac1AnalysisFilterBank AnalysisFilterBank[2];
 
     const std::vector<float> LoudnessCurve;
     std::vector<std::unique_ptr<NAtrac1::IAtrac1BitAlloc>> BitAllocs;
@@ -117,7 +117,7 @@ class TAtrac1Decoder : public IProcessor, public TAtrac1MDCT {
     int32_t PcmValueMax = 1;
     int32_t PcmValueMin = -1;
 
-    Atrac1SynthesisFilterBank<float> SynthesisFilterBank[2];
+    Atrac1SynthesisFilterBank SynthesisFilterBank[2];
 public:
     TAtrac1Decoder(TCompressedInputPtr&& aea);
     TPCMEngine::TProcessLambda GetLambda() override;

--- a/src/atrac3denc.h
+++ b/src/atrac3denc.h
@@ -89,7 +89,7 @@ class TAtrac3Encoder : public IProcessor, public TAtrac3MDCT {
 
     float PrevPeak[2][4] = {{0.0}}; //2 channel, 4 band - peak level (after windowing), used to check overflow during scalling
 
-    Atrac3AnalysisFilterBank<float> AnalysisFilterBank[2];
+    Atrac3AnalysisFilterBank AnalysisFilterBank[2];
 
     TScaler<TAtrac3Data> Scaler;
     std::vector<NAtrac3::TAtrac3BitStreamWriter::TSingleChannelElement> SingleChannelElements;


### PR DESCRIPTION
- Remove unused TQmf template pcm type parameter
- Do not copy buffer twice in the synthesis fb