### PR TITLE
Fix operator precedence in MDCT malloc size calculation

### DIFF
--- a/src/lib/mdct/mdct.cpp
+++ b/src/lib/mdct/mdct.cpp
@@ -39,8 +39,8 @@ TMDCTBase::TMDCTBase(size_t n, float scale)
     : N(n)
     , SinCos(CalcSinCos(n, scale))
 {
-    FFTIn = (kiss_fft_cpx*) malloc(sizeof(kiss_fft_cpx) * N >> 2);
-    FFTOut = (kiss_fft_cpx*) malloc(sizeof(kiss_fft_cpx) * N >> 2);
+    FFTIn = (kiss_fft_cpx*) malloc(sizeof(kiss_fft_cpx) * (N >> 2));
+    FFTOut = (kiss_fft_cpx*) malloc(sizeof(kiss_fft_cpx) * (N >> 2));
     FFTPlan = kiss_fft_alloc(N >> 2, false, nullptr, nullptr);
 }
 


### PR DESCRIPTION
## Summary
- `sizeof(kiss_fft_cpx) * N >> 2` parsed as `(sizeof * N) >> 2` not `sizeof * (N >> 2)`
- Currently correct by coincidence (sizeof=8, so 8*N/4 = 8*(N/4) = 2*N)
- Adding parentheses makes intent explicit and prevents future bugs

## Test plan
- [ ] Verify unit tests pass
- [ ] No behavioral change expected (same result with current types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)