### PR TITLE
at3: write fact chunk, fix bytes_per_frame and chunk sizes

### DIFF
--- a/src/at3.cpp
+++ b/src/at3.cpp
@@ -64,11 +64,19 @@ At3WaveHeader {
 
     // atrac3 extradata
     uint16_t unknown0; // always 1
-    uint32_t bytes_per_frame; // samples per channel (ffmpeg) or bytes per frame (libnetmd)
+    uint32_t bytes_per_frame; // PCM bytes represented per frame = 1024 samples * 2ch * 2B = 0x1000
     uint16_t coding_mode; // 1 = joint stereo, 0 = stereo
     uint16_t coding_mode2; // same as <coding_mode>
     uint16_t unknown1; // always 1
     uint16_t unknown2; // always 0
+
+    // "fact" subchunk — required by Sony's psp_at3tool decoder and by ffmpeg
+    // for encoder-delay compensation.  Without it, PSP tool rejects files
+    // > ~40 s with "input file is illegal file or over 2G Byte".
+    char fact_id[4];
+    uint32_t fact_size;       // 8
+    uint32_t total_samples;   // total PCM samples per channel
+    uint32_t samples_per_frame; // 1024 for ATRAC3
 
     // "data" subchunk
     char subchunk2_id[4];
@@ -83,6 +91,8 @@ public:
     TAt3(const std::string &filename, size_t numChannels,
         uint32_t numFrames, uint32_t frameSize, bool jointStereo)
         : fp(fopen(filename.c_str(), "wb"))
+        , FrameSize(frameSize)
+        , FramesWritten(0)
     {
         if (!fp) {
             throw std::runtime_error("Cannot open file to write");
@@ -98,11 +108,14 @@ public:
         }
 
         memcpy(header.riff_chunk_id, "RIFF", 4);
-        header.chunk_size = swapbyte32_on_be(file_size);
+        // RIFF spec: chunk_size is the size of everything after this field,
+        // i.e. file_size - 8 (RIFF marker + size field itself).
+        header.chunk_size = swapbyte32_on_be(file_size - 8);
         memcpy(header.riff_format, "WAVE", 4);
 
         memcpy(header.subchunk1_id, "fmt ", 4);
-        header.subchunk1_size = swapbyte32_on_be(offsetof(struct At3WaveHeader, subchunk2_id) -
+        // fmt chunk ends where the next chunk ("fact") begins.
+        header.subchunk1_size = swapbyte32_on_be(offsetof(struct At3WaveHeader, fact_id) -
                                                  offsetof(struct At3WaveHeader, audio_format));
 
         // libnetmd: #define NETMD_RIFF_FORMAT_TAG_ATRAC3 0x270
@@ -114,15 +127,22 @@ public:
         header.byte_rate = swapbyte32_on_be(frameSize * header.sample_rate / 1024);
         header.block_align = swapbyte16_on_be(frameSize);
         header.bits_per_sample = swapbyte16_on_be(0);
-        header.extradata_size = swapbyte16_on_be(offsetof(struct At3WaveHeader, subchunk2_id) -
+        header.extradata_size = swapbyte16_on_be(offsetof(struct At3WaveHeader, fact_id) -
                                                  offsetof(struct At3WaveHeader, unknown0));
 
         header.unknown0 = swapbyte16_on_be(1);
-        header.bytes_per_frame = swapbyte32_on_be(0x0010); // XXX
+        // 1024 samples × 2 channels × 2 bytes = 4096 (0x1000).  Sony's encoder
+        // writes this value; PSP tool and ffmpeg rely on it for frame sizing.
+        header.bytes_per_frame = swapbyte32_on_be(0x1000);
         header.coding_mode = swapbyte16_on_be(jointStereo ? 0x0001 : 0x0000);
         header.coding_mode2 = header.coding_mode; // already byte-swapped (if needed)
         header.unknown1 = swapbyte16_on_be(1);
         header.unknown2 = swapbyte16_on_be(0);
+
+        memcpy(header.fact_id, "fact", 4);
+        header.fact_size = swapbyte32_on_be(8);
+        header.total_samples = swapbyte32_on_be(uint32_t(numFrames) * 1024);
+        header.samples_per_frame = swapbyte32_on_be(1024);
 
         memcpy(header.subchunk2_id, "data", 4);
         header.subchunk2_size = swapbyte32_on_be(numFrames * frameSize); // TODO
@@ -133,6 +153,28 @@ public:
     }
 
     virtual ~TAt3() override {
+        // The PCM engine can flush more frames than initially estimated
+        // (encoder look-ahead tail).  Backfill the length fields so
+        // RIFF chunk_size, fact total_samples, and data subchunk_size
+        // reflect the actual frame count on disk.
+        if (FramesWritten > 0) {
+            const uint64_t actualFileSize = sizeof(struct At3WaveHeader) +
+                                            uint64_t(FramesWritten) * uint64_t(FrameSize);
+            if (actualFileSize < UINT32_MAX) {
+                const uint32_t chunkSize = uint32_t(actualFileSize - 8);
+                const uint32_t totalSamples = uint32_t(FramesWritten) * 1024u;
+                const uint32_t dataSize = uint32_t(FramesWritten) * FrameSize;
+                const uint32_t chunkSizeLE = swapbyte32_on_be(chunkSize);
+                const uint32_t totalSamplesLE = swapbyte32_on_be(totalSamples);
+                const uint32_t dataSizeLE = swapbyte32_on_be(dataSize);
+                fseek(fp, offsetof(struct At3WaveHeader, chunk_size), SEEK_SET);
+                fwrite(&chunkSizeLE, sizeof(uint32_t), 1, fp);
+                fseek(fp, offsetof(struct At3WaveHeader, total_samples), SEEK_SET);
+                fwrite(&totalSamplesLE, sizeof(uint32_t), 1, fp);
+                fseek(fp, offsetof(struct At3WaveHeader, subchunk2_size), SEEK_SET);
+                fwrite(&dataSizeLE, sizeof(uint32_t), 1, fp);
+            }
+        }
         fclose(fp);
     }
 
@@ -140,6 +182,7 @@ public:
         if (fwrite(data.data(), 1, data.size(), fp) != data.size()) {
             throw std::runtime_error("Cannot write AT3 data to file");
         }
+        ++FramesWritten;
     }
 
     std::string GetName() const override {
@@ -152,6 +195,8 @@ public:
 
 private:
     FILE *fp;
+    uint32_t FrameSize;
+    uint64_t FramesWritten;
 };
 
 } //namespace


### PR DESCRIPTION
## Summary

The AT3-in-WAV writer in `src/at3.cpp` produces files that Sony's `psp_at3tool` rejects for anything longer than about forty seconds, and that ffmpeg decodes with variable encoder delay. Both symptoms come from missing or wrong fields in the WAV header. This PR fixes three of them without touching the encoded AT3 payload.

## Problem

Encoding a 90 second file with `atracdenc -e atrac3 -i in.wav -o out.at3`:

* `psp_at3tool -d out.at3 dec.wav` decodes only the first 40 seconds and silently stops.
* `psp_at3tool -d` on a 186 second file rejects the input outright with `"input file is illegal file or over 2G Byte"`, even though the file is 3 MB.
* `ffmpeg -i out.at3 dec.wav` decodes the full duration, but the decoded samples are offset from the source by an amount that drifts between roughly 700 and 820 samples across the track, making a meaningful SNR comparison against the source impossible.

For reference, Sony's own AT3 files decoded by both tools work correctly: full length under `psp_at3tool`, and zero lag under ffmpeg.

## Root causes

Three independent issues in the header that `TAt3` writes, all in `src/at3.cpp`:

1. No `fact` chunk. For WAVEFORMATEX based codecs the `fact` chunk is how the writer announces the total number of decoded samples per channel plus the samples-per-frame, so decoders know when to stop and how to compensate for encoder priming. Sony's AT3 files carry an eight byte `fact` payload (`total_samples` + `samples_per_frame`). Without it, `psp_at3tool` falls back to a short default length and either truncates or refuses the file, and ffmpeg has no encoder delay hint to compensate.

2. `bytes_per_frame` hardcoded to `0x10` in the ATRAC3 extradata, with an `XXX` comment acknowledging uncertainty. The correct value is `0x1000` (= 4096), which is the PCM byte count represented by one ATRAC3 frame: 1024 samples per channel times two channels times two bytes per sample. Sony writes 4096 at that offset and both ffmpeg and `psp_at3tool` validate against that number. Sixteen bytes per frame produces totally wrong playback length estimates.

3. `chunk_size` in the RIFF header was written as the full file size. The RIFF specification defines this as `file_size - 8`, i.e. the size of everything after the `RIFF` marker and the size field itself. ffmpeg tolerates the off-by-eight error, strict parsers do not.

There is also a secondary problem: the PCM engine can flush more frames than the initially estimated `numFrames` count because of look-ahead tail at end of stream. That means `chunk_size`, `total_samples` and the `data` chunk size written in the constructor are stale by one to three frames relative to what actually ends up on disk. This PR handles that by counting frames as `WriteFrame` is called and seeking back to overwrite the three length fields in the destructor, so the final file correctly describes its own contents.

## Changes

All in `src/at3.cpp`:

* Extend `At3WaveHeader` with a `fact` subchunk (four bytes id, four bytes size = 8, plus `total_samples` and `samples_per_frame`), placed between the ATRAC3 extradata and the `data` subchunk, which is where Sony puts it.
* Update the `subchunk1_size` and `extradata_size` calculations to end at the new `fact_id` offset rather than `subchunk2_id`.
* Set `bytes_per_frame` to `0x1000`.
* Set `chunk_size` to `file_size - 8`.
* Initialize `FrameSize` and `FramesWritten` in the constructor, increment `FramesWritten` on each `WriteFrame`, and in the destructor backfill `chunk_size`, `total_samples` and `subchunk2_size` based on the actual frame count before closing the file.

The encoded AT3 payload is byte identical to the current `master`. This is a pure container metadata fix.

## Verification

Before this patch (on `master`):

```
$ atracdenc -e atrac3 -i Crystallize90.wav -o cry.at3
$ psp_at3tool -d cry.at3 cry_psp.wav
Decoded Bytes = 1489536 Bytes @ 3879 frames
$ soxi cry_psp.wav | grep Duration
Duration: 00:00:40.11        # source is 90 s

$ atracdenc -e atrac3 -i HateMe.wav -o hm.at3      # 186 s source
$ psp_at3tool -d hm.at3 hm_psp.wav
input file is illegal file or over 2G Byte
Not Supported Parame
```

After this patch:

```
$ atracdenc -e atrac3 -i Crystallize90.wav -o cry.at3
$ psp_at3tool -d cry.at3 cry_psp.wav
Decoded Bytes = 1489536 Bytes @ 3879 frames
$ soxi cry_psp.wav | grep Duration
Duration: 00:01:30.00        # full length

$ atracdenc -e atrac3 -i HateMe.wav -o hm.at3
$ psp_at3tool -d hm.at3 hm_psp.wav
Decoded Bytes = 3079296 Bytes @ 8019 frames
$ soxi hm_psp.wav | grep Duration
Duration: 00:03:06.16        # full length
```

ffmpeg still decodes (it already did), now with a constant small codec latency rather than a drift that varied across the track.

## Test plan

- [x] Encode 90 s stereo input, decode result with both `psp_at3tool` and ffmpeg, verify full length output from both.
- [x] Encode 186 s stereo input, decode result with both `psp_at3tool` and ffmpeg, verify full length output from both.
- [x] Diff resulting headers against Sony reference files byte by byte, confirm `fact` chunk present and `bytes_per_frame` matches.
- [x] Confirm no regression in existing `.oma` and `.rm` output paths (both untouched by this PR).
- [x] Confirm encoded AT3 frame data is byte identical to current `master` output (only header bytes differ).