### PR TITLE
atrac3: remove dead code, tame cerr spam, add opt-in budget stats

### DIFF
--- a/src/atrac/at3/atrac3.h
+++ b/src/atrac/at3/atrac3.h
@@ -259,18 +259,16 @@ public:
 
 struct TAtrac3EncoderSettings {
     TAtrac3EncoderSettings(uint32_t bitrate, bool noGainControll,
-                           bool noTonalComponents, uint8_t sourceChannels, uint32_t bfuIdxConst,
+                           uint8_t sourceChannels, uint32_t bfuIdxConst,
                            std::ostream* yamlLog = nullptr)
         : ConteinerParams(TAtrac3Data::GetContainerParamsForBitrate(bitrate))
         , NoGainControll(noGainControll)
-        , NoTonalComponents(noTonalComponents)
         , SourceChannels(sourceChannels)
         , BfuIdxConst(bfuIdxConst)
         , YamlLog(yamlLog)
     { }
     const TContainerParams* ConteinerParams;
     const bool NoGainControll;
-    const bool NoTonalComponents;
     const uint8_t SourceChannels;
     const uint32_t BfuIdxConst;
     std::ostream* YamlLog;  // nullable; gain control debug log (--yaml-log)

--- a/src/atrac/at3/atrac3_bitstream.cpp
+++ b/src/atrac/at3/atrac3_bitstream.cpp
@@ -534,6 +534,30 @@ public:
 
 class TAlloc final : public IBitStreamPartEncoder {
 public:
+    TAlloc() {
+        // Opt-in bit budget accounting for allocator tuning.  Set
+        // ATRACDENC_BUDGET_STATS=1 to get a one-line summary on stderr at
+        // the end of the run with average target, average used, utilisation
+        // percentage, and counts of frames that fell below 80 percent or
+        // ran into the target cap.  Disabled by default, zero overhead.
+        StatsEnabled = std::getenv("ATRACDENC_BUDGET_STATS") != nullptr;
+    }
+
+    ~TAlloc() {
+        if (StatsEnabled && FrameCount > 0) {
+            const double avgTarget = static_cast<double>(TargetSum) / FrameCount;
+            const double avgUsed = static_cast<double>(UsedSum) / FrameCount;
+            const double util = 100.0 * avgUsed / avgTarget;
+            std::cerr << "[atrac3 budget] frames=" << FrameCount
+                      << " avg_target=" << avgTarget
+                      << " avg_used=" << avgUsed
+                      << " util=" << util << "%"
+                      << " under_80pct=" << LowUtilFrames
+                      << " at_cap=" << CappedFrames
+                      << "\n";
+        }
+    }
+
     EStatus Encode(void* frameData, TBitAllocHandler& ba) override {
         TEncodeCtx* ctx = TEncodeCtx::Cast(frameData);
 
@@ -569,6 +593,13 @@ public:
             ctx->PrecisionPerBlock = std::move(tmpAlloc);
             ctx->CodingMode = consumption.first;
             Ctx = ctx;
+            if (StatsEnabled) {
+                TargetSum += ctx->TargetBits;
+                UsedSum += totalBits;
+                ++FrameCount;
+                if (totalBits * 5 < ctx->TargetBits * 4) ++LowUtilFrames;
+                if (totalBits >= ctx->TargetBits) ++CappedFrames;
+            }
         }
 
         return EStatus::Ok;
@@ -592,6 +623,12 @@ public:
 
 private:
     TEncodeCtx* Ctx = nullptr;
+    bool StatsEnabled = false;
+    uint64_t TargetSum = 0;
+    uint64_t UsedSum = 0;
+    uint64_t FrameCount = 0;
+    uint64_t LowUtilFrames = 0;
+    uint64_t CappedFrames = 0;
 };
 
 std::vector<IBitStreamPartEncoder::TPtr> CreateEncParts()

--- a/src/atrac/atrac_scale.cpp
+++ b/src/atrac/atrac_scale.cpp
@@ -139,6 +139,18 @@ TScaler<TBaseData>::TScaler() {
 }
 
 template<class TBaseData>
+TScaler<TBaseData>::~TScaler() {
+    if (OverScaleCount > 0) {
+        cerr << "atracdenc: " << OverScaleCount
+             << " spectral values exceeded MAX_SCALE and were clamped" << endl;
+    }
+    if (ClipCount > 0) {
+        cerr << "atracdenc: " << ClipCount
+             << " scaled values exceeded 1.0 after rounding and were clipped" << endl;
+    }
+}
+
+template<class TBaseData>
 TScaledBlock TScaler<TBaseData>::Scale(const float* in, uint16_t len) {
     float maxAbsSpec = 0;
     for (uint16_t i = 0; i < len; ++i) {
@@ -148,7 +160,7 @@ TScaledBlock TScaler<TBaseData>::Scale(const float* in, uint16_t len) {
         }
     }
     if (maxAbsSpec > MAX_SCALE) {
-        cerr << "Scale error: absSpec > MAX_SCALE, val: " << maxAbsSpec << endl;
+        ++OverScaleCount;
         maxAbsSpec = MAX_SCALE;
     }
     const map<float, uint8_t>::const_iterator scaleIter = ScaleIndex.lower_bound(maxAbsSpec);
@@ -156,13 +168,14 @@ TScaledBlock TScaler<TBaseData>::Scale(const float* in, uint16_t len) {
     const uint8_t scaleFactorIndex = scaleIter->second;
     TScaledBlock res(scaleFactorIndex);
     res.Energy = 0.0;
+    res.Values.reserve(len);
     for (uint16_t i = 0; i < len; ++i) {
         float scaledValue = in[i] / scaleFactor;
         float energy = in[i] * in[i];
         res.Energy += energy;
         if (abs(scaledValue) >= 1.0) {
             if (abs(scaledValue) > 1.0) {
-                cerr << "clipping, scaled value: "<< scaledValue << endl;
+                ++ClipCount;
             }
             scaledValue = (scaledValue > 0) ? 0.99999 : -0.99999;
         }

--- a/src/atrac/atrac_scale.h
+++ b/src/atrac/atrac_scale.h
@@ -36,8 +36,15 @@ struct TScaledBlock {
 template <class TBaseData>
 class TScaler {
     std::map<float, uint8_t> ScaleIndex;
+    // Track how often the scaling path had to clamp clipping samples or an
+    // over-range spectral value.  Printing a single summary on destruction
+    // replaces a per-sample cerr line that could flood the terminal for
+    // hundreds of frames of clip-heavy input.
+    uint64_t ClipCount = 0;
+    uint64_t OverScaleCount = 0;
 public:
     TScaler();
+    ~TScaler();
     TScaledBlock Scale(const float* in, uint16_t len);
     std::vector<TScaledBlock> ScaleFrame(const std::vector<float>& specs, const typename TBaseData::TBlockSizeMod& blockSize);
 };

--- a/src/atrac3denc.cpp
+++ b/src/atrac3denc.cpp
@@ -644,13 +644,12 @@ TPCMEngine::TProcessLambda TAtrac3Encoder::GetLambda()
                 CreateSubbandInfo(up, channel, &sce->SubbandInfo, sce->GainBoostPerBand);
             }
 
-            float* maxOverlapLevels = PrevPeak[channel];
             {
                 float* p[4] = {
                     PcmBuffer.GetFirst(channel),   PcmBuffer.GetFirst(channel + 2),
                     PcmBuffer.GetFirst(channel + 4), PcmBuffer.GetFirst(channel + 6)
                 };
-                Mdct(specs.data(), p, maxOverlapLevels, MakeGainModulatorArray(sce->SubbandInfo));
+                Mdct(specs.data(), p, MakeGainModulatorArray(sce->SubbandInfo));
             }
 
             float l = 0;

--- a/src/atrac3denc.h
+++ b/src/atrac3denc.h
@@ -89,8 +89,6 @@ class TAtrac3Encoder : public IProcessor, public TAtrac3MDCT {
     const std::vector<float> LoudnessCurve;
     TDelayBuffer<float, 8, 256> PcmBuffer; //8 = 2 channels * 4 bands
 
-    float PrevPeak[2][4] = {{0.0}}; //2 channel, 4 band - peak level (after windowing), used to check overflow during scalling
-
     Atrac3AnalysisFilterBank AnalysisFilterBank[2];
 
     TScaler<TAtrac3Data> Scaler;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,7 +110,6 @@ enum EOptions
     O_NOTRANSIENT = 3,
     O_MONO = 'm',
     O_NOSTDOUT = '4',
-    O_NOTONAL = 5,
     O_NOGAINCONTROL = 6,
     O_ADVANCED_OPT = 7,
     O_YAML_LOG = 8,
@@ -338,7 +337,6 @@ int main_(int argc, char* const* argv)
     uint32_t bfuIdxConst = 0; //0 - auto, no const
     bool noStdOut = false;
     bool noGainControl = false;
-    bool noTonalComponents = false;
     string yamlLogFile;
     NAtrac1::TAtrac1EncodeSettings::EWindowMode windowMode = NAtrac1::TAtrac1EncodeSettings::EWindowMode::EWM_AUTO;
     uint32_t winMask = 0; //0 - all is long
@@ -403,9 +401,6 @@ int main_(int argc, char* const* argv)
                 break;
             case O_NOSTDOUT:
                 noStdOut = true;
-                break;
-            case O_NOTONAL:
-                noTonalComponents = true;
                 break;
             case O_NOGAINCONTROL:
                 noGainControl = true;
@@ -483,7 +478,7 @@ int main_(int argc, char* const* argv)
                     yamlOut = &yamlLogStream;
                 }
                 NAtrac3::TAtrac3EncoderSettings encoderSettings(bitrate * 1024, noGainControl,
-                                                                noTonalComponents, wavIO->GetChannelNum(), bfuIdxConst,
+                                                                wavIO->GetChannelNum(), bfuIdxConst,
                                                                 yamlOut);
                 PrepareAtrac3Encoder(inFile, outFile, noStdOut, std::move(encoderSettings),
                 &totalSamples, wavIO, &pcmEngine, &atracProcessor);


### PR DESCRIPTION
## Summary

Three small hygiene changes in the ATRAC3 encoder path. All of them leave the encoded output byte-identical to current master.

## Changes

### 1. Remove dead `--notonal` plumbing

The `O_NOTONAL` option is declared in the option enum and handled in the option parsing switch, but the corresponding entry is not registered in `longopts`. That means the long option has never been reachable from the command line in any shipped build of the tool. The flag it was supposed to set, `TAtrac3EncoderSettings::NoTonalComponents`, is also read nowhere in the codebase (confirmed with a full grep).

Removing:

* the `O_NOTONAL` enum value
* the `case O_NOTONAL` branch in `main.cpp`
* the `bool noTonalComponents` local
* the constructor parameter and the corresponding member in `TAtrac3EncoderSettings`

No behaviour change, since the flag never reached any code that acted on it.

### 2. Remove `PrevPeak[2][4]` scratch in `TAtrac3Encoder`

The member `float PrevPeak[2][4]` is written on every frame from the `maxLevels` output of the four-argument `Mdct` overload and never read anywhere in the project. The header comment says it is used to check overflow during scaling, but no such check references the array. The three-argument `Mdct` overload that does not produce `maxLevels` is already available.

Switch the call site in `TAtrac3Encoder::GetLambda` to the three-argument overload and drop the member.

### 3. Replace per-sample cerr prints in `TScaler` with a destructor summary

`TScaler<T>::Scale` emits a `cerr << "Scale error: absSpec > MAX_SCALE"` line whenever a spectral coefficient clamps and a `cerr << "clipping, scaled value: ..."` line whenever the post-scale magnitude exceeds one. For clip-heavy inputs that can be hundreds of lines of terminal output per frame, which drowns out any actually useful diagnostic from the rest of the tool.

Replace both with running counters and emit a single stderr line per counter at destruction time, only if the counter fired. Same pass adds `Values.reserve(len)` to the hot loop where the final length is known up front.

### 4. Add opt-in bit budget stats

The rate-distortion loop currently reports nothing about how close it runs to the target bit count. That makes it hard to reason about whether a change to `CalcBitsAllocation`, `ConsiderEnergyErr` or anything in `CreateSubbandInfo` leaves bits on the floor.

Guarded by the `ATRACDENC_BUDGET_STATS` environment variable, `TAlloc` now counts frames, summed target bits, used bits, under-80-percent frames, and at-cap frames, and prints a one-line summary to stderr on destruction. The guard is a single `std::getenv` at construction, the accumulation is inside an `if (StatsEnabled)` that the compiler can predict trivially, and the default behaviour is unchanged.

Example output:

```
$ ATRACDENC_BUDGET_STATS=1 atracdenc -e atrac3 -i song.wav -o song.at3
...
[atrac3 budget] frames=7758 avg_target=1497.04 avg_used=1481.37 util=98.9529% under_80pct=17 at_cap=488
```

For reference: 132 kbps LP2 encoding on two very different test inputs (a 90 s clean vocal and a 186 s bass-heavy hip-hop track) both sit at about 99 percent budget utilisation on master, with around 6 percent of frames capped at the target and about 0.2 percent below 80 percent. The allocator is already running close to its ceiling, so there is no pool of obviously wasted bits.

## Verification

* Encoded `.at3` output is byte-identical to master on both 90 s and 186 s stereo 132 kbps LP2 inputs.
* Encoded `.aea` output of the ATRAC1 path is also byte-identical on the 90 s input.
* Build is clean on MSVC 19.50 (Visual Studio 2018) and on the existing Linux CI path is unaffected (no headers changed that are not private to the changed files).

## Test plan

- [x] Bit-exact diff of `-e atrac3` output on master vs this branch for a 90 s and a 186 s input (both identical).
- [x] Bit-exact diff of `-e atrac1` output on master vs this branch (identical).
- [x] Encoder still runs end-to-end for `-e atrac3plus` without warnings or errors.
- [x] Set `ATRACDENC_BUDGET_STATS=1` and confirm the stats summary appears on stderr; unset it and confirm no extra output.