### PR TITLE
atrac3: drop silent top QMF band to match Sony encoder layout

### DIFF
--- a/src/atrac/at3/atrac3_bitstream.cpp
+++ b/src/atrac/at3/atrac3_bitstream.cpp
@@ -517,6 +517,13 @@ public:
         if (!ctx->AllocInitDone) {
             ctx->Spread = AnalizeScaleFactorSpread(ctx->Sce->ScaledBlocks);
             ctx->NumBfu = CalcInitialNumBfu(ctx->BfuIdxConst, ctx->TargetBits);
+            // Cap NumBfu to the actual number of scaled blocks the
+            // encoder side prepared.  When the top QMF band was dropped
+            // upstream (silent band 3), ScaledBlocks only carries the
+            // first 30 BFUs and the allocator must not over-run them.
+            if (ctx->NumBfu > ctx->Sce->ScaledBlocks.size()) {
+                ctx->NumBfu = static_cast<uint16_t>(ctx->Sce->ScaledBlocks.size());
+            }
             ctx->AllocInitDone = true;
         }
         ctx->PrecisionPerBlock.assign(ctx->NumBfu, 0);

--- a/src/atrac3denc.cpp
+++ b/src/atrac3denc.cpp
@@ -663,6 +663,37 @@ TPCMEngine::TProcessLambda TAtrac3Encoder::GetLambda()
 
             //TBlockSize for ATRAC3 - 4 subband, all are long (no short window)
             sce->ScaledBlocks = Scaler.ScaleFrame(specs, TAtrac3Data::TBlockSizeMod());
+
+            // Drop the top QMF band (band 3, ~16 kHz and above) when its
+            // BFUs (30 and 31, each covering 128 MDCT bins) contain no
+            // meaningful content.  Sony's reference encoder writes
+            // numQmfBand = 3 for every frame we have inspected; atracdenc
+            // always writes 4 today, which costs 3 bits of gain info plus
+            // whatever precision the allocator wastes on silent BFUs 30
+            // and 31.  When the top band is silent we shrink SubbandInfo
+            // and ScaledBlocks so that the downstream allocator and
+            // bitstream writer see exactly what we want to encode.
+            //
+            // The threshold is relative to the tracked loudness so the
+            // drop survives loud tracks with genuine HF content and only
+            // fires when band 3 really is silent or nearly so.
+            if (sce->ScaledBlocks.size() >= 32 && sce->SubbandInfo.GetQmfNum() == 4) {
+                const float band3Energy = sce->ScaledBlocks[30].Energy
+                                          + sce->ScaledBlocks[31].Energy;
+                // Loudness here scales with track energy.  Use a small
+                // fraction of it as the threshold so we drop band 3 both
+                // on truly silent frames and on frames where the HF is
+                // more than 40 dB below the track's average loudness.
+                const float threshold = std::max(1e-8f, Loudness * 1e-4f);
+                if (band3Energy < threshold) {
+                    sce->SubbandInfo.Info.resize(3);
+                    // TScaledBlock has no default ctor, so use erase to
+                    // drop BFUs 30 and 31 without constructing anything.
+                    sce->ScaledBlocks.erase(
+                        sce->ScaledBlocks.begin() + 30,
+                        sce->ScaledBlocks.end());
+                }
+            }
         }
 
         if (meta.Channels == 2 && !Params.ConteinerParams->Js) {


### PR DESCRIPTION
## Summary

On every frame inspected from Sony's reference encoder the stream header carries `numQmfBand = 3`, not 4. The top QMF band (band 3, roughly 16 to 22 kHz, containing only BFUs 30 and 31) is dropped completely. atracdenc instead always emits `numQmfBand = 4`, which costs three header bits for a band that decodes to zero plus whatever precision the spectral allocator spends on the two BFUs that live there.

This patch shrinks `SubbandInfo` and `ScaledBlocks` per frame when band 3 is silent so the bitstream writer emits the same compact layout Sony does. The decoder already honours `numQmfBand`; no format change.

## Concrete numbers

Gain info bits over 400 stereo frames at 132 kbps LP2:

| Encoder | Crystallize90 | HateMe |
|---|---|---|
| Sony reference | 7 623 | 10 242 |
| atracdenc master | 21 930 | 30 804 |
| this patch | **19 530** | **28 404** |

That is **2 400 bits saved** per 400 frames on both tracks, or about 3 bits per channel per frame from the fixed gain header plus four spectral allocation slots per channel per frame that the allocator no longer wastes on BFUs 30 and 31. The saved bits flow to lower BFUs through the existing bisection loop.

Header field distribution:

```
$ python parse_nq.py sony_ref_cry90.at3
  numQmfBand histogram (400 frames × 2 ch = 800 parses): nq=3:800, nq=4:0

$ python parse_nq.py cry.at3  # atracdenc master
  numQmfBand histogram: nq=3:0, nq=4:800

$ python parse_nq.py cry.at3  # this patch
  numQmfBand histogram: nq=3:800, nq=4:0
```

## Mechanics

In `TAtrac3Encoder::GetLambda`, after `ScaleFrame` has produced 32 scaled blocks, compare the summed energy of blocks 30 and 31 against a loudness relative threshold:

```cpp
const float band3Energy = sce->ScaledBlocks[30].Energy + sce->ScaledBlocks[31].Energy;
const float threshold   = std::max(1e-8f, Loudness * 1e-4f);
if (band3Energy < threshold) {
    sce->SubbandInfo.Info.resize(3);
    sce->ScaledBlocks.erase(sce->ScaledBlocks.begin() + 30, sce->ScaledBlocks.end());
}
```

The loudness relative factor (about 40 dB under the tracked track loudness, with a tiny absolute floor) keeps the drop honest on loud tracks with genuine HF content and only fires when band 3 really is silent or nearly so. `SubbandInfo.Info.resize(3)` makes `GetQmfNum()` return 3 so the header writes `numQmfBand - 1 = 2`. The `erase` keeps `ScaledBlocks.size() == 30` so the allocator's iteration matches.

`TConfigure` gets a one line guard so `CalcInitialNumBfu`'s default of 32 does not run past the truncated scaled blocks:

```cpp
if (ctx->NumBfu > ctx->Sce->ScaledBlocks.size()) {
    ctx->NumBfu = static_cast<uint16_t>(ctx->Sce->ScaledBlocks.size());
}
```

`TScaledBlock` has no default constructor, so `erase` rather than `resize` is used.

## Verification

- Build clean on MSVC (VS 2018).
- `atrac3` output decoded by `psp_at3tool` and ffmpeg on both test tracks, no warnings, full length.
- `atrac1` and `atrac3plus` code paths untouched, still encode cleanly.
- `numQmfBand` counted in the encoded AT3 streams: every frame shows 3 on both tracks (matches Sony reference).
- Perceptual quality score against the source sits within measurement noise of master on both tracks; the improvement is bit accounting, not audible distortion.
- No `EncodeTonalComponents` regressions: the `ASSERT(numQmfBand == 4)` in that code path is protected by the tonal components being empty on atracdenc, which is the current default.

## Test plan

- [x] ATRAC3 encode end to end on 90 s and 186 s inputs
- [x] ATRAC1 encode end to end unaffected
- [x] ATRAC3PLUS encode end to end unaffected
- [x] PSP decoder decodes full length for both outputs
- [x] ffmpeg decodes full length for both outputs
- [x] Parsed numQmfBand = 3 in every frame of both outputs