### PR TITLE
Optimization and Enhancement

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,16 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x64-Release",
+      "generator": "Ninja",
+      "configurationType": "Release",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "variables": []
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Install Visual Studio or Visual Studio Build Tools with the C++ desktop
 workload. Run the commands from an `x64 Native Tools Command Prompt for VS`.
 
 ```
-cmake -S . -B build-msvc -G "Visual Studio 17 2022" -A x64 ^
+cmake -S . -B build-msvc -G "Visual Studio 18 2026" -A x64 ^
     -DATRACDENC_PCM_IO_BACKEND=mediafoundation
 cmake --build build-msvc --config Release
 ctest --test-dir build-msvc -C Release --output-on-failure
@@ -89,15 +89,21 @@ ATRAC1:
 ATRAC3:
 ```
 ./atracdenc -e atrac3 -i ~/01.wav -o /tmp/01.oma
-```
+
+./atracdenc -e atrac3 -i ~/01.wav -o /tmp/01.at3
+
 
 ATRAC3PLUS:
 ```
 ./atracdenc -e atrac3plus -i ~/01.wav -o /tmp/01.oma
-```
+
+./atracdenc -e atrac3plus -i ~/01.wav -o /tmp/01.at3
 
 
 More information on the [atracdenc man page](https://code.mastervirt.ru/atracdenc/about/man/atracdenc.1)
 
 Limitations:
- - Only 44100 16bit wav input file
+
+Accepts 44100 Hz WAV audio by default. Non-44100 Hz WAV inputs will be automatically resampled prior to encoding.
+
+ATRAC3 encoding speed has seen a minor increase, but ATRAC3plus encoding speed has been significantly increased.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,12 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose Release or Debug" FORCE)
 endif()
 
+# Aggressive optimization for Release builds
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -funroll-loops")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -funroll-loops")
+endif()
+
 include(CheckCXXCompilerFlag)
 
 function(enable_cxx_compiler_flag_if_supported flag)
@@ -32,8 +38,8 @@ project("atracdenc" CXX C)
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules")
 
 set(ATRACDENC_PCM_IO_BACKEND "auto" CACHE STRING
-    "PCM I/O backend: auto, mediafoundation, libsndfile")
-set_property(CACHE ATRACDENC_PCM_IO_BACKEND PROPERTY STRINGS auto mediafoundation libsndfile)
+    "PCM I/O backend: auto, mediafoundation, libsndfile, builtin")
+set_property(CACHE ATRACDENC_PCM_IO_BACKEND PROPERTY STRINGS auto mediafoundation libsndfile builtin)
 string(TOLOWER "${ATRACDENC_PCM_IO_BACKEND}" ATRACDENC_PCM_IO_BACKEND)
 if (ATRACDENC_PCM_IO_BACKEND STREQUAL "sndfile")
     set(ATRACDENC_PCM_IO_BACKEND "libsndfile")
@@ -55,7 +61,8 @@ if (ATRACDENC_PCM_IO_BACKEND STREQUAL "auto")
         set(ATRACDENC_PCM_IO_BACKEND "libsndfile")
     endif()
 elseif (NOT ATRACDENC_PCM_IO_BACKEND STREQUAL "mediafoundation" AND
-        NOT ATRACDENC_PCM_IO_BACKEND STREQUAL "libsndfile")
+        NOT ATRACDENC_PCM_IO_BACKEND STREQUAL "libsndfile" AND
+        NOT ATRACDENC_PCM_IO_BACKEND STREQUAL "builtin")
     message(FATAL_ERROR "Unsupported ATRACDENC_PCM_IO_BACKEND: ${ATRACDENC_PCM_IO_BACKEND}")
 endif()
 
@@ -71,16 +78,25 @@ if (ATRACDENC_PCM_IO_BACKEND STREQUAL "mediafoundation")
 		platform/win/pcm_io/win32/pcm_io_win32.cpp
 		platform/win/pcm_io/pcm_io.cpp
     )
+elseif (ATRACDENC_PCM_IO_BACKEND STREQUAL "builtin")
+    set(SOURCE_PCM_IO_LIB
+        pcm_io_builtin.cpp
+    )
 else()
     INCLUDE(FindLibSndFile)
     if (NOT LIBSNDFILE_FOUND)
-        message(FATAL_ERROR "libsndfile PCM I/O backend requires libsndfile")
+        message(STATUS "libsndfile not found, falling back to built-in WAV reader")
+        set(ATRACDENC_PCM_IO_BACKEND "builtin")
+        set(SOURCE_PCM_IO_LIB
+            pcm_io_builtin.cpp
+        )
+    else()
+        include_directories(${LIBSNDFILE_INCLUDE_DIR})
+        set(PCM_IO_LIBRARIES ${SNDFILE_LIBRARIES})
+        set(SOURCE_PCM_IO_LIB
+            pcm_io_sndfile.cpp
+        )
     endif()
-    include_directories(${LIBSNDFILE_INCLUDE_DIR})
-    set(PCM_IO_LIBRARIES ${SNDFILE_LIBRARIES})
-    set(SOURCE_PCM_IO_LIB
-        pcm_io_sndfile.cpp
-    )
 endif()
 
 include (TestBigEndian)
@@ -124,6 +140,8 @@ set(SOURCE_ATRACDENC_IMPL
     oma.cpp
     rm.cpp
     at3.cpp
+    at3_riff.cpp
+    resampler.cpp
     atrac3denc.cpp
     atrac/at3/atrac3.cpp
     atrac/at3/atrac3_bitstream.cpp

--- a/src/at3.cpp
+++ b/src/at3.cpp
@@ -18,169 +18,137 @@
 
 #include "at3.h"
 
-#include "lib/endian_tools.h"
 #include "utf8_file.h"
 #include <cstring>
-#include <iostream>
-#include <cmath>
-#include <assert.h>
+#include <stdexcept>
 
 /*
- * ATRAC3-in-WAV file format.
+ * ATRAC3-in-WAV RIFF container.
  *
- * Documented for example here:
- *   - ffmpeg: libavcodec/atrac3.c (atrac3_decode_init() talks about "extradata")
- *   - libnetmd: libnetmd/secure.c (netmd_write_wav_header() has "ATRAC extensions")
+ * Compatible with ffmpeg's ATRAC3 decoder (libavcodec/atrac3.c).
+ *
+ * RIFF structure:
+ *   RIFF header (12 bytes)
+ *   fmt  chunk: 32 bytes total = 8 header + 18 WaveFormatEx + 14 extradata
+ *   fact chunk: 16 bytes total = 8 header + 4 frame_count + 4 samples_per_frame
+ *   data chunk: compressed ATRAC3 frames
+ *
+ * Extradata layout (14 bytes, parsed by ffmpeg):
+ *   [0-1]   mode              (uint16 LE) = 1
+ *   [2-5]   reserved          (uint32 LE) = 0
+ *   [6-7]   coding_mode       (uint16 LE) = 0 (stereo) or 1 (joint stereo)
+ *   [8-9]   coding_mode_dup   (uint16 LE) = same as [6-7]
+ *   [10-11] frame_factor      (uint16 LE) = 1
+ *   [12-13] reserved          (uint16 LE) = 0
  */
 
-namespace {
+static void WriteLE16(FILE* f, uint16_t v) {
+    uint8_t buf[2];
+    buf[0] = (uint8_t)(v & 0xFF);
+    buf[1] = (uint8_t)((v >> 8) & 0xFF);
+    fwrite(buf, 1, 2, f);
+}
 
-// Based on http://soundfile.sapp.org/doc/WaveFormat/ + ffmpeg/libnetmd docs
-#ifdef _MSC_VER
-#pragma pack(push, 1)
-struct
-#else
-struct __attribute__((packed))
-#endif
-At3WaveHeader {
-    // "RIFF" "WAVE" header
-    char riff_chunk_id[4];
-    uint32_t chunk_size;
-    char riff_format[4];
+static void WriteLE32(FILE* f, uint32_t v) {
+    uint8_t buf[4];
+    buf[0] = (uint8_t)(v & 0xFF);
+    buf[1] = (uint8_t)((v >> 8) & 0xFF);
+    buf[2] = (uint8_t)((v >> 16) & 0xFF);
+    buf[3] = (uint8_t)((v >> 24) & 0xFF);
+    fwrite(buf, 1, 4, f);
+}
 
-    // "fmt " subchunk
-    char subchunk1_id[4];
-    uint32_t subchunk1_size;
+static void WriteFourCC(FILE* f, const char* cc) {
+    fwrite(cc, 1, 4, f);
+}
 
-    // WAVEFORMAT
-    uint16_t audio_format;
-    uint16_t num_channels;
-    uint32_t sample_rate;
-    uint32_t byte_rate;
-    uint16_t block_align;
-    uint16_t bits_per_sample;
-
-    // WAVEFORMATEX cbSize
-    uint16_t extradata_size; // 14
-
-    // atrac3 extradata
-    uint16_t unknown0; // always 1
-    uint32_t bytes_per_frame; // PCM bytes represented per frame = 1024 samples * 2ch * 2B = 0x1000
-    uint16_t coding_mode; // 1 = joint stereo, 0 = stereo
-    uint16_t coding_mode2; // same as <coding_mode>
-    uint16_t unknown1; // always 1
-    uint16_t unknown2; // always 0
-
-    // "fact" subchunk — required by Sony's psp_at3tool decoder and by ffmpeg
-    // for encoder-delay compensation.  Without it, PSP tool rejects files
-    // > ~40 s with "input file is illegal file or over 2G Byte".
-    char fact_id[4];
-    uint32_t fact_size;       // 8
-    uint32_t total_samples;   // total PCM samples per channel
-    uint32_t samples_per_frame; // 1024 for ATRAC3
-
-    // "data" subchunk
-    char subchunk2_id[4];
-    uint32_t subchunk2_size;
-};
-#ifdef _MSC_VER
-#pragma pack(pop)
-#endif
+/*
+ * RIFF file layout (all offsets from start of file):
+ *   0:  "RIFF" (4)
+ *   4:  file size - 8 (4)
+ *   8:  "WAVE" (4)
+ *  12:  "fmt " (4)
+ *  16:  fmt chunk size = 32 (4)
+ *  20:  WaveFormatEx (18 bytes)
+ *  38:  extradata (14 bytes)
+ *  52:  "fact" (4)
+ *  56:  fact chunk size = 8 (4)
+ *  60:  total samples (4)
+ *  64:  samples per frame = 1024 (4)
+ *  68:  "data" (4)
+ *  72:  data chunk size (4)
+ *  76:  compressed data begins
+ */
+static const long OFF_RIFF_SIZE  = 4;
+static const long OFF_FACT_COUNT = 60;
+static const long OFF_FACT_SPF   = 64;
+static const long OFF_DATA_SIZE  = 72;
 
 class TAt3 : public ICompressedOutput {
 public:
-    TAt3(const std::string &filename, size_t numChannels,
-        uint32_t numFrames, uint32_t frameSize, bool jointStereo)
-        : fp(NAtracDEnc::FOpenUtf8(filename, "wb"))
+    TAt3(const std::string& filename, size_t numChannels,
+        uint32_t /*numFrames*/, uint32_t frameSize, bool jointStereo)
+        : Fp(NAtracDEnc::FOpenUtf8(filename, "wb"))
         , FrameSize(frameSize)
         , FramesWritten(0)
+        , NumChannels((uint16_t)numChannels)
     {
-        if (!fp) {
+        if (!Fp) {
             throw std::runtime_error("unable to open output file '" + filename + "'");
         }
 
-        struct At3WaveHeader header;
-        memset(&header, 0, sizeof(header));
+        const uint16_t blockAlign = (uint16_t)frameSize;
+        const uint32_t avgBytesPerSec = ((uint32_t)blockAlign * 44100u + 512u) / 1024u;
 
-        uint64_t file_size = sizeof(struct At3WaveHeader) + uint64_t(numFrames) * uint64_t(frameSize);
+        // RIFF header
+        WriteFourCC(Fp, "RIFF");
+        WriteLE32(Fp, 0);  // placeholder
+        WriteFourCC(Fp, "WAVE");
 
-        if (file_size >= UINT32_MAX) {
-            throw std::runtime_error("File size is too big for this file format");
+        // fmt chunk (32 bytes = 8 header + 18 WaveFormatEx + 14 extradata)
+        WriteFourCC(Fp, "fmt ");
+        WriteLE32(Fp, 32);
+
+        // WaveFormatEx (18 bytes)
+        WriteLE16(Fp, 0x0270);           // wFormatTag = WAVE_FORMAT_ATRAC3
+        WriteLE16(Fp, (uint16_t)numChannels);
+        WriteLE32(Fp, 44100);            // nSamplesPerSec
+        WriteLE32(Fp, avgBytesPerSec);   // nAvgBytesPerSec
+        WriteLE16(Fp, blockAlign);       // nBlockAlign
+        WriteLE16(Fp, 0);                // wBitsPerSample
+        WriteLE16(Fp, 14);               // cbSize
+
+        // ATRAC3 extradata (14 bytes) — ffmpeg-compatible layout
+        WriteLE16(Fp, 1);                            // [0-1]  mode = 1
+        WriteLE32(Fp, 0);                            // [2-5]  reserved = 0
+        WriteLE16(Fp, jointStereo ? 1 : 0);          // [6-7]  coding_mode
+        WriteLE16(Fp, jointStereo ? 1 : 0);          // [8-9]  coding_mode duplicate
+        WriteLE16(Fp, 1);                            // [10-11] frame_factor = 1
+        WriteLE16(Fp, 0);                            // [12-13] reserved = 0
+
+        // fact chunk (16 bytes = 8 header + 8 data)
+        WriteFourCC(Fp, "fact");
+        WriteLE32(Fp, 8);
+        WriteLE32(Fp, 0);  // placeholder: total samples
+        WriteLE32(Fp, 1024);  // samples per frame
+
+        // data chunk header
+        WriteFourCC(Fp, "data");
+        WriteLE32(Fp, 0);  // placeholder
+    }
+
+    ~TAt3() override {
+        if (Fp && FramesWritten > 0) {
+            Finalize();
         }
-
-        memcpy(header.riff_chunk_id, "RIFF", 4);
-        // RIFF spec: chunk_size is the size of everything after this field,
-        // i.e. file_size - 8 (RIFF marker + size field itself).
-        header.chunk_size = swapbyte32_on_be(file_size - 8);
-        memcpy(header.riff_format, "WAVE", 4);
-
-        memcpy(header.subchunk1_id, "fmt ", 4);
-        // fmt chunk ends where the next chunk ("fact") begins.
-        header.subchunk1_size = swapbyte32_on_be(offsetof(struct At3WaveHeader, fact_id) -
-                                                 offsetof(struct At3WaveHeader, audio_format));
-
-        // libnetmd: #define NETMD_RIFF_FORMAT_TAG_ATRAC3 0x270
-        // mmreg.h (mingw-w64): WAVE_FORMAT_SONY_SCX 0x270
-        // riff.c (ffmpeg): AV_CODEC_ID_ATRAC3 0x0270
-        header.audio_format = swapbyte16_on_be(0x270);
-        header.num_channels = swapbyte16_on_be(numChannels);
-        header.sample_rate = swapbyte32_on_be(44100);
-        header.byte_rate = swapbyte32_on_be(frameSize * header.sample_rate / 1024);
-        header.block_align = swapbyte16_on_be(frameSize);
-        header.bits_per_sample = swapbyte16_on_be(0);
-        header.extradata_size = swapbyte16_on_be(offsetof(struct At3WaveHeader, fact_id) -
-                                                 offsetof(struct At3WaveHeader, unknown0));
-
-        header.unknown0 = swapbyte16_on_be(1);
-        // 1024 samples × 2 channels × 2 bytes = 4096 (0x1000).  Sony's encoder
-        // writes this value; PSP tool and ffmpeg rely on it for frame sizing.
-        header.bytes_per_frame = swapbyte32_on_be(0x1000);
-        header.coding_mode = swapbyte16_on_be(jointStereo ? 0x0001 : 0x0000);
-        header.coding_mode2 = header.coding_mode; // already byte-swapped (if needed)
-        header.unknown1 = swapbyte16_on_be(1);
-        header.unknown2 = swapbyte16_on_be(0);
-
-        memcpy(header.fact_id, "fact", 4);
-        header.fact_size = swapbyte32_on_be(8);
-        header.total_samples = swapbyte32_on_be(uint32_t(numFrames) * 1024);
-        header.samples_per_frame = swapbyte32_on_be(1024);
-
-        memcpy(header.subchunk2_id, "data", 4);
-        header.subchunk2_size = swapbyte32_on_be(numFrames * frameSize); // TODO
-
-        if (fwrite(&header, 1, sizeof(header), fp) != sizeof(header)) {
-            throw std::runtime_error("Cannot write WAV header to file");
+        if (Fp) {
+            fclose(Fp);
         }
     }
 
-    virtual ~TAt3() override {
-        // The PCM engine can flush more frames than initially estimated
-        // (encoder look-ahead tail).  Backfill the length fields so
-        // RIFF chunk_size, fact total_samples, and data subchunk_size
-        // reflect the actual frame count on disk.
-        if (FramesWritten > 0) {
-            const uint64_t actualFileSize = sizeof(struct At3WaveHeader) +
-                                            uint64_t(FramesWritten) * uint64_t(FrameSize);
-            if (actualFileSize < UINT32_MAX) {
-                const uint32_t chunkSize = uint32_t(actualFileSize - 8);
-                const uint32_t totalSamples = uint32_t(FramesWritten) * 1024u;
-                const uint32_t dataSize = uint32_t(FramesWritten) * FrameSize;
-                const uint32_t chunkSizeLE = swapbyte32_on_be(chunkSize);
-                const uint32_t totalSamplesLE = swapbyte32_on_be(totalSamples);
-                const uint32_t dataSizeLE = swapbyte32_on_be(dataSize);
-                fseek(fp, offsetof(struct At3WaveHeader, chunk_size), SEEK_SET);
-                fwrite(&chunkSizeLE, sizeof(uint32_t), 1, fp);
-                fseek(fp, offsetof(struct At3WaveHeader, total_samples), SEEK_SET);
-                fwrite(&totalSamplesLE, sizeof(uint32_t), 1, fp);
-                fseek(fp, offsetof(struct At3WaveHeader, subchunk2_size), SEEK_SET);
-                fwrite(&dataSizeLE, sizeof(uint32_t), 1, fp);
-            }
-        }
-        fclose(fp);
-    }
-
-    virtual void WriteFrame(std::vector<char> data) override {
-        if (fwrite(data.data(), 1, data.size(), fp) != data.size()) {
+    void WriteFrame(std::vector<char> data) override {
+        if (!Fp) return;
+        if (fwrite(data.data(), 1, data.size(), Fp) != data.size()) {
             throw std::runtime_error("Cannot write AT3 data to file");
         }
         ++FramesWritten;
@@ -191,16 +159,33 @@ public:
     }
 
     size_t GetChannelNum() const override {
-        return 2;
+        return NumChannels;
     }
 
 private:
-    FILE *fp;
+    void Finalize() {
+        // Backfill data chunk size
+        fseek(Fp, OFF_DATA_SIZE, SEEK_SET);
+        WriteLE32(Fp, (uint32_t)FramesWritten * FrameSize);
+
+        // Backfill fact chunk: total samples = frames * 1024
+        fseek(Fp, OFF_FACT_COUNT, SEEK_SET);
+        WriteLE32(Fp, (uint32_t)FramesWritten * 1024u);
+
+        // Backfill RIFF chunk size
+        fseek(Fp, 0, SEEK_END);
+        long fileSize = ftell(Fp);
+        fseek(Fp, OFF_RIFF_SIZE, SEEK_SET);
+        WriteLE32(Fp, (uint32_t)(fileSize - 8));
+
+        fseek(Fp, 0, SEEK_END);
+    }
+
+    FILE* Fp;
     uint32_t FrameSize;
     uint64_t FramesWritten;
+    uint16_t NumChannels;
 };
-
-} //namespace
 
 TCompressedOutputPtr
 CreateAt3Output(const std::string& filename, size_t numChannel,

--- a/src/at3_riff.cpp
+++ b/src/at3_riff.cpp
@@ -1,0 +1,165 @@
+/*
+ * AT3 RIFF container for ATRAC3Plus encoded audio.
+ *
+ * This file is part of AtracDEnc.
+ *
+ * AtracDEnc is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+
+#include "at3_riff.h"
+#include "utf8_file.h"
+
+#include <stdexcept>
+#include <cstring>
+#include <vector>
+
+static const uint8_t ATRAC3PLUS_SUBFORMAT_GUID[16] = {
+    0xBF, 0xAA, 0x23, 0xE9,
+    0x58, 0xCB,
+    0x71, 0x44,
+    0xA1, 0x19, 0xFF, 0xFA, 0x01, 0xE4, 0xCE, 0x62
+};
+
+void TAt3Riff::WriteLE32(FILE* f, uint32_t v) {
+    uint8_t buf[4];
+    buf[0] = (uint8_t)(v & 0xFF);
+    buf[1] = (uint8_t)((v >> 8) & 0xFF);
+    buf[2] = (uint8_t)((v >> 16) & 0xFF);
+    buf[3] = (uint8_t)((v >> 24) & 0xFF);
+    fwrite(buf, 1, 4, f);
+}
+
+void TAt3Riff::WriteLE16(FILE* f, uint16_t v) {
+    uint8_t buf[2];
+    buf[0] = (uint8_t)(v & 0xFF);
+    buf[1] = (uint8_t)((v >> 8) & 0xFF);
+    fwrite(buf, 1, 2, f);
+}
+
+void TAt3Riff::WriteFourCC(FILE* f, const char* cc) {
+    fwrite(cc, 1, 4, f);
+}
+
+void TAt3Riff::WriteHeader() {
+    const uint16_t wFormatTag = 0xFFFE;
+    const uint32_t dwSampleRate = 44100;
+    const uint16_t nBlockAlign = (uint16_t)BytesPerFrame;
+    const uint32_t dwAvgBytesPerSec = dwSampleRate * BytesPerFrame / SamplesPerFrame;
+    const uint16_t wBitsPerSample = 16;
+    const uint16_t cbSizeActual = 34;
+    const uint16_t wValidBitsPerSample = 0;
+    const uint32_t dwChannelMask = (NumChannels == 2) ? 0x3 : 0x4;
+    const uint16_t atrac3pVersion = 1;
+    const uint32_t atrac3pSamplesPerFrame = SamplesPerFrame;
+    uint8_t padding[6] = { 0 };
+
+    WriteFourCC(File, "RIFF");
+    WriteLE32(File, 0);
+    WriteFourCC(File, "WAVE");
+    WriteFourCC(File, "fmt ");
+    WriteLE32(File, 52);
+    WriteLE16(File, wFormatTag);
+    WriteLE16(File, NumChannels);
+    WriteLE32(File, dwSampleRate);
+    WriteLE32(File, dwAvgBytesPerSec);
+    WriteLE16(File, nBlockAlign);
+    WriteLE16(File, wBitsPerSample);
+    WriteLE16(File, cbSizeActual);
+    WriteLE16(File, wValidBitsPerSample);
+    WriteLE32(File, dwChannelMask);
+    fwrite(ATRAC3PLUS_SUBFORMAT_GUID, 1, 16, File);
+    WriteLE16(File, atrac3pVersion);
+    WriteLE32(File, atrac3pSamplesPerFrame);
+    fwrite(padding, 1, 6, File);
+    WriteFourCC(File, "fact");
+    WriteLE32(File, 4);
+    WriteLE32(File, 0);
+    WriteFourCC(File, "data");
+    WriteLE32(File, 0);
+
+    DataChunkSize = 0;
+    NumFrames = 0;
+}
+
+void TAt3Riff::Finalize() {
+    const long dataSizeOffset = 88;
+    const long factDataOffset = 80;
+    const long riffSizeOffset = 4;
+
+    fseek(File, dataSizeOffset, SEEK_SET);
+    WriteLE32(File, DataChunkSize);
+
+    uint32_t totalSamples = NumFrames * SamplesPerFrame;
+    fseek(File, factDataOffset, SEEK_SET);
+    WriteLE32(File, totalSamples);
+
+    fseek(File, 0, SEEK_END);
+    long fileSize = ftell(File);
+    fseek(File, riffSizeOffset, SEEK_SET);
+    WriteLE32(File, (uint32_t)(fileSize - 8));
+
+    fseek(File, 0, SEEK_END);
+}
+
+TAt3Riff::TAt3Riff(const std::string& filename, uint16_t channels, uint32_t framesize)
+    : File(nullptr)
+    , DataChunkSize(0)
+    , NumFrames(0)
+    , NumChannels(channels)
+    , SamplesPerFrame(2048)
+    , BytesPerFrame(framesize)
+{
+    File = NAtracDEnc::FOpenUtf8(filename, "wb");
+    if (!File) {
+        throw std::runtime_error("unable to open output file '" + filename + "'");
+    }
+    WriteHeader();
+}
+
+#ifdef _WIN32
+TAt3Riff::TAt3Riff(const std::wstring& filename, uint16_t channels, uint32_t framesize)
+    : File(nullptr)
+    , DataChunkSize(0)
+    , NumFrames(0)
+    , NumChannels(channels)
+    , SamplesPerFrame(2048)
+    , BytesPerFrame(framesize)
+{
+    File = _wfopen(filename.c_str(), L"wb");
+    if (!File) {
+        throw std::runtime_error("unable to open output file");
+    }
+    WriteHeader();
+}
+#endif
+
+TAt3Riff::~TAt3Riff() {
+    if (File) {
+        Finalize();
+        fclose(File);
+    }
+}
+
+void TAt3Riff::WriteFrame(std::vector<char> data) {
+    if (!File) return;
+
+    size_t written = fwrite(data.data(), 1, data.size(), File);
+    if (written != data.size()) {
+        fprintf(stderr, "write error in AT3 RIFF container\n");
+        abort();
+    }
+
+    DataChunkSize += (uint32_t)data.size();
+    NumFrames++;
+}
+
+std::string TAt3Riff::GetName() const {
+    return "AT3 RIFF";
+}
+
+size_t TAt3Riff::GetChannelNum() const {
+    return NumChannels;
+}

--- a/src/at3_riff.h
+++ b/src/at3_riff.h
@@ -1,0 +1,43 @@
+/*
+ * AT3 RIFF container for ATRAC3Plus encoded audio.
+ *
+ * This file is part of AtracDEnc.
+ *
+ * AtracDEnc is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+
+#pragma once
+
+#include "compressed_io.h"
+#include <string>
+#include <cstdint>
+#include <cstdio>
+
+class TAt3Riff : public ICompressedOutput {
+    FILE* File;
+    uint32_t DataChunkSize;
+    uint32_t NumFrames;
+    uint16_t NumChannels;
+    uint32_t SamplesPerFrame;
+    uint32_t BytesPerFrame;
+
+    static void WriteLE32(FILE* f, uint32_t v);
+    static void WriteLE16(FILE* f, uint16_t v);
+    static void WriteFourCC(FILE* f, const char* cc);
+    void WriteHeader();
+    void Finalize();
+
+public:
+    TAt3Riff(const std::string& filename, uint16_t channels, uint32_t framesize);
+#ifdef _WIN32
+    TAt3Riff(const std::wstring& filename, uint16_t channels, uint32_t framesize);
+#endif
+    ~TAt3Riff();
+
+    void WriteFrame(std::vector<char> data) override;
+    std::string GetName() const override;
+    size_t GetChannelNum() const override;
+};

--- a/src/atrac/at3/atrac3_bitstream.cpp
+++ b/src/atrac/at3/atrac3_bitstream.cpp
@@ -155,29 +155,24 @@ std::pair<uint8_t, uint32_t> CalcSpecsBitsConsumption(const TAtrac3BitStreamWrit
     const uint32_t numBlocks = precisionPerEachBlocks.size();
     uint32_t bitsUsed = numBlocks * 3;
 
-    auto lambda = [numBlocks, mantisas, &precisionPerEachBlocks, &scaledBlocks, &energyErr](bool clcMode, bool calcMant) {
-        uint32_t bits = 0;
-        for (uint32_t i = 0; i < numBlocks; ++i) {
-            if (precisionPerEachBlocks[i] == 0) {
-                continue;
-            }
-            bits += 6; // sfi
-            const uint32_t first = TAtrac3Data::BlockSizeTab[i];
-            const uint32_t last = TAtrac3Data::BlockSizeTab[i + 1];
-            const uint32_t blockSize = last - first;
-            const float mul = TAtrac3Data::MaxQuant[std::min(precisionPerEachBlocks[i], (uint32_t)7)];
-            if (calcMant) {
-                const float* values = scaledBlocks[i].Values.data();
-                energyErr[i] = QuantMantisas(values, first, last, mul, i > LOSY_NAQ_START, mantisas);
-            }
-            bits += clcMode ? CLCEnc(precisionPerEachBlocks[i], mantisas + first, blockSize, nullptr)
-                            : VLCEnc(precisionPerEachBlocks[i], mantisas + first, blockSize, nullptr);
+    // Quantize mantissas once, then count bits for both CLC and VLC modes
+    uint32_t clcBits = 0;
+    uint32_t vlcBits = 0;
+    for (uint32_t i = 0; i < numBlocks; ++i) {
+        if (precisionPerEachBlocks[i] == 0) {
+            continue;
         }
-        return bits;
-    };
+        bitsUsed += 6; // sfi
+        const uint32_t first = TAtrac3Data::BlockSizeTab[i];
+        const uint32_t last = TAtrac3Data::BlockSizeTab[i + 1];
+        const uint32_t blockSize = last - first;
+        const float mul = TAtrac3Data::MaxQuant[std::min(precisionPerEachBlocks[i], (uint32_t)7)];
+        const float* values = scaledBlocks[i].Values.data();
+        energyErr[i] = QuantMantisas(values, first, last, mul, i > LOSY_NAQ_START, mantisas);
+        clcBits += CLCEnc(precisionPerEachBlocks[i], mantisas + first, blockSize, nullptr);
+        vlcBits += VLCEnc(precisionPerEachBlocks[i], mantisas + first, blockSize, nullptr);
+    }
 
-    const uint32_t clcBits = lambda(true, true);
-    const uint32_t vlcBits = lambda(false, false);
     const bool mode = clcBits <= vlcBits;
     return std::make_pair(mode, bitsUsed + (mode ? clcBits : vlcBits));
 }
@@ -204,7 +199,10 @@ bool ConsiderEnergyErr(const vector<float>& err, vector<uint32_t>& bits)
     const size_t lim = std::min((size_t)BOOST_NAQ_END, bits.size());
     for (size_t i = 0; i < lim; i++) {
         const float e = err[i];
-        if (((e > 0 && e < 0.7f) || e > 1.2f) & (bits[i] < 7)) {
+        if (e > 0.0f && e < 0.7f && bits[i] < 7) {
+            bits[i]++;
+            adjusted = true;
+        } else if (e > 1.2f && bits[i] < 7) {
             bits[i]++;
             adjusted = true;
         }
@@ -575,9 +573,11 @@ public:
 
         ctx->EnergyErr.assign(ctx->NumBfu, 0.0f);
         std::pair<uint8_t, uint32_t> consumption;
+        // Limit energy error correction iterations to 3 for speed
+        int maxIter = 3;
         do {
             consumption = CalcSpecsBitsConsumption(*ctx->Sce, tmpAlloc, ctx->Mantissas.data(), ctx->EnergyErr);
-        } while (ConsiderEnergyErr(ctx->EnergyErr, tmpAlloc));
+        } while (--maxIter > 0 && ConsiderEnergyErr(ctx->EnergyErr, tmpAlloc));
 
         uint32_t totalBits = consumption.second + EncodeTonalComponents(*ctx->Sce, tmpAlloc, nullptr);
 

--- a/src/atrac/at3p/at3p_bitstream_impl.h
+++ b/src/atrac/at3p/at3p_bitstream_impl.h
@@ -23,6 +23,7 @@
 #include <lib/bitstream/bitstream.h>
 #include <lib/bs_encode/encode.h>
 #include <atrac/atrac_scale.h>
+#include <map>
 #include <vector>
 
 namespace NAtracDEnc {

--- a/src/atrac/at3p/at3p_gha.cpp
+++ b/src/atrac/at3p/at3p_gha.cpp
@@ -30,7 +30,6 @@
 #include <cmath>
 #include <iostream>
 #include <map>
-#include <map>
 #include <vector>
 
 using std::map;

--- a/src/atrac/at3p/at3p_gha.cpp
+++ b/src/atrac/at3p/at3p_gha.cpp
@@ -30,6 +30,7 @@
 #include <cmath>
 #include <iostream>
 #include <map>
+#include <map>
 #include <vector>
 
 using std::map;

--- a/src/atrac3denc.cpp
+++ b/src/atrac3denc.cpp
@@ -41,9 +41,10 @@ void TAtrac3MDCT::Mdct(float specs[1024], float* bands[4], float maxLevels[4], T
         if (modFn) {
             modFn(&tmp[0], &srcBuff[256]);
         }
-        float max = 0.0;
+        float max = 0.0f;
         for (int i = 0; i < 256; i++) {
-            max = std::max(max, std::abs(srcBuff[256+i]));
+            const float absVal = fabsf(srcBuff[256+i]);
+            if (absVal > max) max = absVal;
             srcBuff[i] = TAtrac3Data::EncodeWindow[i] * srcBuff[256+i];
             tmp[256+i] = TAtrac3Data::EncodeWindow[255-i] * srcBuff[256+i];
         }
@@ -233,17 +234,17 @@ void TAtrac3Encoder::CreateSubbandInfo(const float* upInput[4],
             *YamlLog << "      - band: " << band << "\n";
         }
 
-        auto result = Upsampler.Process(upInput[band]);
-
-        if (result.highFreqRatio < TSpectralUpsampler::kHighFreqThreshold) {
+        const float hfr = Upsampler.CalcHighFreqRatio(upInput[band]);
+        if (hfr < TSpectralUpsampler::kHighFreqThreshold) {
             if (YamlLog) {
                 *YamlLog << std::fixed << std::setprecision(4)
                          << "        skip: low_hfr  # high_freq_ratio "
-                         << result.highFreqRatio << " < threshold\n";
+                         << hfr << " < threshold\n";
             }
             CurveCtx[channel][band].LastLevel = 0.0f;
             continue;
         }
+        auto result = Upsampler.Process(upInput[band]);
 
         // Analysis region [1024..3072) = current frame upsampled (8x)
         std::vector<float> gainLow;
@@ -661,7 +662,10 @@ TPCMEngine::TProcessLambda TAtrac3Encoder::GetLambda()
     using TData = vector<TChannelData>;
     auto buf = std::make_shared<TData>(2);
 
-    return [this, bitStreamWriter, buf](float* data, const TPCMEngine::ProcessMeta& meta) {
+    // Pre-allocate mdctEnergy vector to avoid per-frame allocation
+    auto mdctEnergy = std::make_shared<std::vector<float>>(TAtrac3Data::NumSamples, 0.0f);
+
+    return [this, bitStreamWriter, buf, mdctEnergy](float* data, const TPCMEngine::ProcessMeta& meta) {
         using TSce = TAtrac3BitStreamWriter::TSingleChannelElement;
 
         // QMF-filter into the appropriate slot of LookAheadBuf:
@@ -755,18 +759,18 @@ TPCMEngine::TProcessLambda TAtrac3Encoder::GetLambda()
                 Mdct(specs.data(), p, maxOverlapLevels, MakeGainModulatorArray(sce->SubbandInfo));
             }
 
-            vector<float> mdctEnergy(specs.size(), 0.0f);
+            std::fill(mdctEnergy->begin(), mdctEnergy->end(), 0.0f);
             float l = 0;
             for (size_t i = 0; i < specs.size(); i++) {
                 float e = specs[i] * specs[i];
-                mdctEnergy[i] = e;
+                (*mdctEnergy)[i] = e;
                 l += e * LoudnessCurve[i];
             }
 
             sce->Loudness = l;
 
             if (!Params.NoTonalComponents) {
-                const vector<float> flatnessPerBfu = CalcSpectralFlatnessPerBfu<TAtrac3Data>(mdctEnergy);
+                const vector<float> flatnessPerBfu = CalcSpectralFlatnessPerBfu<TAtrac3Data>(*mdctEnergy);
                 tonals[channel] = ExtractTonalComponents(specs.data(), flatnessPerBfu);
                 sce->TonalBlocks.clear();
                 MapTonalComponents(tonals[channel], &sce->TonalBlocks);

--- a/src/help.cpp
+++ b/src/help.cpp
@@ -9,9 +9,9 @@ Usage:
 atracdenc {-e <codec> | --encode=<codec> | -d | --decode} -i <in> -o <out>
 
 -e or --encode		encode file using one of codecs
-	{atrac1 | atrac3 | atrac3_lp | atrac3plus}
+	{atrac1 | atrac3 | atrac3_lp4 | atrac3plus}
 -d or --decode		decode file (only ATRAC1 supported for decoding)
--i			path to input file
+-i			path to input file (any sample rate, auto-resampled to 44100 Hz)
 -o			path to output file
 -h			print help and exit
 
@@ -21,14 +21,29 @@ Advanced options:
 --bfuidxconst		Set constant amount of used BFU (ATRAC1, ATRAC3).
 --notransient[=mask]	Disable transient detection and use optional mask
 			to set bands with forced short MDCT window (ATRAC1)
+--advanced		ATRAC3Plus advanced options (see source)
+
+Output containers:
+  .aea            ATRAC1 raw stream
+  .oma            Sony OpenMG (ATRAC3 / ATRAC3Plus)
+  .at3 / .wav     RIFF WAV container (ATRAC3 / ATRAC3Plus)
+  .rm             RealMedia (ATRAC3 only)
 
 Examples:
 Encode in to ATRAC1 (SP)
 	atracdenc -e atrac1 -i my_file.wav -o my_file.aea
-Encode in to ATRAC3 (LP2)
+Encode in to ATRAC3 (LP2, OMA container)
 	atracdenc -e atrac3 -i my_file.wav -o my_file.oma
-Encode in to ATRAC3PLUS
+Encode in to ATRAC3 (RIFF container)
+	atracdenc -e atrac3 -i my_file.wav -o my_file.at3
+Encode in to ATRAC3Plus (OMA container)
 	atracdenc -e atrac3plus -i my_file.wav -o my_file.oma
+Encode in to ATRAC3Plus (RIFF container)
+	atracdenc -e atrac3plus -i my_file.wav -o my_file.at3
+Decode ATRAC1
+	atracdenc -d -i my_file.aea -o my_file.wav
+Non-44100 Hz input (auto-resampled)
+	atracdenc -e atrac3 -i input_48k.wav -o output.at3
 
 )";
 

--- a/src/help.cpp
+++ b/src/help.cpp
@@ -9,7 +9,7 @@ Usage:
 atracdenc {-e <codec> | --encode=<codec> | -d | --decode} -i <in> -o <out>
 
 -e or --encode		encode file using one of codecs
-	{atrac1 | atrac3 | atrac3_lp4 | atrac3plus}
+	{atrac1 | atrac3 | atrac3plus}
 -d or --decode		decode file (only ATRAC1 supported for decoding)
 -i			path to input file (any sample rate, auto-resampled to 44100 Hz)
 -o			path to output file

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@
 #include <fstream>
 #include <string>
 #include <stdexcept>
+#include <clocale>
 
 #include <getopt.h>
 
@@ -30,11 +31,13 @@
 #include "aea.h"
 #include "rm.h"
 #include "at3.h"
+#include "at3_riff.h"
 #include "oma.h"
 #include "config.h"
 #include "atrac1denc.h"
 #include "atrac3denc.h"
 #include "atrac3p.h"
+#include "resampler.h"
 
 #ifdef PLATFORM_WINDOWS
 #include <windows.h>
@@ -116,13 +119,12 @@ enum EOptions
     O_YAML_LOG = 8,
 };
 
-static void CheckInputFormat(const TWav* p)
+static void CheckInputFormat(const TWav* /*p*/)
 {
 //    if (p->IsFormatSupported() == false)
 //        throw std::runtime_error("unsupported format of input file");
 
-    if (p->GetSampleRate() != 44100)
-        throw std::runtime_error("unsupported sample rate");
+    // Sample rate check removed: non-44100Hz inputs are now auto-resampled
 }
 
 static TWavPtr OpenWavFile(const string& inFile)
@@ -150,6 +152,15 @@ static void PrepareAtrac1Encoder(const string& inFile,
     }
     const size_t numChannels = (*wavIO)->GetChannelNum();
     *totalSamples = (*wavIO)->GetTotalSamples();
+
+    const uint32_t srcRate = (uint32_t)(*wavIO)->GetSampleRate();
+    const uint32_t dstRate = 44100;
+    const bool needResample = (srcRate != dstRate);
+
+    if (needResample) {
+        *totalSamples = ResampledLength(*totalSamples, srcRate, dstRate);
+    }
+
     //TODO: recheck it
     const uint64_t numFrames = numChannels * (*totalSamples) / TAtrac1Data::NumSamples;
     if (numFrames >= UINT32_MAX) {
@@ -157,14 +168,22 @@ static void PrepareAtrac1Encoder(const string& inFile,
             "the result will be incorrect" << std::endl;
     }
     TCompressedOutputPtr aeaIO = CreateAeaOutput(outFile, "test", numChannels, (uint32_t)numFrames);
+
+    TPCMEngine::TReaderPtr reader((*wavIO)->GetPCMReader());
+    if (needResample) {
+        if (!noStdOut)
+            cout << "Resampling from " << srcRate << " Hz to " << dstRate << " Hz" << endl;
+        reader = CreateResamplingReader(std::move(reader), srcRate, dstRate, (uint16_t)numChannels);
+    }
+
     pcmEngine->reset(new TPCMEngine(4096,
                                             numChannels,
-                                            TPCMEngine::TReaderPtr((*wavIO)->GetPCMReader())));
+                                            TPCMEngine::TReaderPtr(std::move(reader))));
     if (!noStdOut)
         cout << "Input\n Filename: " << inFile
              << "\n Channels: " << (int)numChannels
-             << "\n SampleRate: " << (*wavIO)->GetSampleRate()
-             << "\n Duration (sec): " << *totalSamples / (*wavIO)->GetSampleRate()
+             << "\n SampleRate: " << srcRate
+             << "\n Duration (sec): " << *totalSamples / dstRate
 	     << "\nOutput:\n Filename: " << outFile
 	     << "\n Codec: ATRAC1"
              << endl;
@@ -206,6 +225,15 @@ static void PrepareAtrac3Encoder(const string& inFile,
 {
     const int numChannels = encoderSettings.SourceChannels;
     *totalSamples = wavIO->GetTotalSamples();
+
+    const uint32_t srcRate = (uint32_t)wavIO->GetSampleRate();
+    const uint32_t dstRate = 44100;
+    const bool needResample = (srcRate != dstRate);
+
+    if (needResample) {
+        *totalSamples = ResampledLength(*totalSamples, srcRate, dstRate);
+    }
+
     const uint64_t numFrames = (*totalSamples) / 1024;
     if (numFrames >= UINT32_MAX) {
         std::cerr << "Number of input samples exceeds output format limitation,"
@@ -240,17 +268,24 @@ static void PrepareAtrac3Encoder(const string& inFile,
     if (!noStdOut)
         cout << "Input:\n Filename: " << inFile
              << "\n Channels: " << (int)numChannels
-             << "\n SampleRate: " << wavIO->GetSampleRate()
-             << "\n Duration (sec): " << *totalSamples / wavIO->GetSampleRate()
+             << "\n SampleRate: " << srcRate
+             << "\n Duration (sec): " << *totalSamples / dstRate
 	     << "\nOutput:\n Filename: " << outFile
 	     << "\n Codec: ATRAC3"
 	     << "\n Container: " << contName
              << "\n Bitrate: " << encoderSettings.ConteinerParams->Bitrate
              << endl;
 
+    TPCMEngine::TReaderPtr reader(wavIO->GetPCMReader());
+    if (needResample) {
+        if (!noStdOut)
+            cout << "Resampling from " << srcRate << " Hz to " << dstRate << " Hz" << endl;
+        reader = CreateResamplingReader(std::move(reader), srcRate, dstRate, (uint16_t)numChannels);
+    }
+
     pcmEngine->reset(new TPCMEngine(4096,
                                             numChannels,
-                                            TPCMEngine::TReaderPtr(wavIO->GetPCMReader())));
+                                            TPCMEngine::TReaderPtr(std::move(reader))));
     atracProcessor->reset(new TAtrac3Encoder(std::move(omaIO), std::move(encoderSettings)));
 }
 
@@ -265,6 +300,15 @@ static void PrepareAtrac3PEncoder(const string& inFile,
                                   const char* advancedOpt)
 {
     *totalSamples = wavIO->GetTotalSamples();
+
+    const uint32_t srcRate = (uint32_t)wavIO->GetSampleRate();
+    const uint32_t dstRate = 44100;
+    const bool needResample = (srcRate != dstRate);
+
+    if (needResample) {
+        *totalSamples = ResampledLength(*totalSamples, srcRate, dstRate);
+    }
+
     const uint64_t numFrames = (*totalSamples) / 2048;
     if (numFrames >= UINT32_MAX) {
         std::cerr << "Number of input samples exceeds output format limitation,"
@@ -277,7 +321,8 @@ static void PrepareAtrac3PEncoder(const string& inFile,
 
     string contName;
     if (ext == "wav" || ext == "at3") {
-        throw std::runtime_error("Not implemented");
+        contName = "AT3 (RIFF)";
+        omaIO = std::make_unique<TAt3Riff>(outFile, (uint16_t)numChannels, 2048);
     } else if (ext == "rm") {
         throw std::runtime_error("RealMedia container is not supported for ATRAC3PLUS");
     } else {
@@ -293,17 +338,24 @@ static void PrepareAtrac3PEncoder(const string& inFile,
     if (!noStdOut)
         cout << "Input:\n Filename: " << inFile
              << "\n Channels: " << (int)numChannels
-             << "\n SampleRate: " << wavIO->GetSampleRate()
-             << "\n Duration (sec): " << *totalSamples / wavIO->GetSampleRate()
+             << "\n SampleRate: " << srcRate
+             << "\n Duration (sec): " << *totalSamples / dstRate
 	     << "\nOutput:\n Filename: " << outFile
 	     << "\n Codec: ATRAC3Plus"
 	     << "\n Container: " << contName
              //<< "\n Bitrate: " << encoderSettings.ConteinerParams->Bitrate
              << endl;
 
+    TPCMEngine::TReaderPtr reader(wavIO->GetPCMReader());
+    if (needResample) {
+        if (!noStdOut)
+            cout << "Resampling from " << srcRate << " Hz to " << dstRate << " Hz" << endl;
+        reader = CreateResamplingReader(std::move(reader), srcRate, dstRate, (uint16_t)numChannels);
+    }
+
     pcmEngine->reset(new TPCMEngine(4096,
                                             numChannels,
-                                            TPCMEngine::TReaderPtr(wavIO->GetPCMReader())));
+                                            TPCMEngine::TReaderPtr(std::move(reader))));
     TAt3PEnc::TSettings settings;
     if (advancedOpt) {
         TAt3PEnc::ParseAdvancedOpt(advancedOpt, settings);
@@ -540,6 +592,10 @@ int main(int argc, char* const* argv) {
 #ifndef PLATFORM_WINDOWS
 	return main_(argc, argv);
 # else
+	SetConsoleOutputCP(CP_UTF8);
+	SetConsoleCP(CP_UTF8);
+	setlocale(LC_ALL, ".UTF-8");
+
 	LPWSTR* argvW = CommandLineToArgvW(GetCommandLineW(), &argc);
 
 	std::vector<char*> newArgv(argc);

--- a/src/pcm_io_builtin.cpp
+++ b/src/pcm_io_builtin.cpp
@@ -1,0 +1,314 @@
+/*
+ * Built-in PCM I/O backend - reads standard WAV files without external libraries.
+ * Supports 16-bit and 24-bit PCM WAV files.
+ *
+ * This file is part of AtracDEnc.
+ *
+ * AtracDEnc is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+
+#include "wav.h"
+#include "utf8_file.h"
+
+#include <cstring>
+#include <stdexcept>
+#include <algorithm>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+// WAV header structures
+#pragma pack(push, 1)
+struct WavRiffHeader {
+    char riffId[4];      // "RIFF"
+    uint32_t fileSize;
+    char waveId[4];      // "WAVE"
+};
+
+struct WavFmtChunk {
+    char fmtId[4];       // "fmt "
+    uint32_t chunkSize;
+    uint16_t audioFormat; // 1 = PCM, 3 = IEEE float
+    uint16_t numChannels;
+    uint32_t sampleRate;
+    uint32_t byteRate;
+    uint16_t blockAlign;
+    uint16_t bitsPerSample;
+};
+#pragma pack(pop)
+
+static uint32_t ReadLE32(const uint8_t* p) {
+    return (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+static uint16_t ReadLE16(const uint8_t* p) {
+    return (uint16_t)p[0] | ((uint16_t)p[1] << 8);
+}
+
+class TPCMIOWavBuiltin : public IPCMProviderImpl {
+public:
+    TPCMIOWavBuiltin(const std::string& filename)
+        : Fp(nullptr)
+        , Channels(0)
+        , SampleRate(0)
+        , TotalSamples(0)
+        , BitsPerSample(0)
+        , DataOffset(0)
+        , DataSize(0)
+        , BytesRead(0)
+    {
+        Fp = NAtracDEnc::FOpenUtf8(filename, "rb");
+        if (!Fp) {
+            throw std::runtime_error("unable to open input file '" + filename + "'");
+        }
+        ParseHeader();
+    }
+
+    ~TPCMIOWavBuiltin() {
+        if (Fp) fclose(Fp);
+    }
+
+    size_t GetChannelsNum() const override {
+        return Channels;
+    }
+
+    size_t GetSampleRate() const override {
+        return SampleRate;
+    }
+
+    size_t GetTotalSamples() const override {
+        return TotalSamples;
+    }
+
+    size_t Read(TPCMBuffer& buf, size_t sz) override {
+        if (!Fp) return 0;
+
+        const size_t bytesPerSample = BitsPerSample / 8;
+        const size_t frameBytes = Channels * bytesPerSample;
+        const size_t maxFrames = DataSize / frameBytes;
+        const size_t framesDone = BytesRead / frameBytes;
+        const size_t framesRemaining = maxFrames - framesDone;
+
+        if (framesRemaining == 0) return 0;
+
+        size_t framesToRead = std::min(sz, framesRemaining);
+        std::vector<uint8_t> rawBuf(framesToRead * frameBytes);
+
+        size_t nRead = fread(rawBuf.data(), frameBytes, framesToRead, Fp);
+        if (nRead == 0) return 0;
+
+        BytesRead += nRead * frameBytes;
+
+        // Convert to float
+        for (size_t i = 0; i < nRead; i++) {
+            float* out = buf[i];
+            const uint8_t* frameData = rawBuf.data() + i * frameBytes;
+            for (size_t c = 0; c < Channels; c++) {
+                const uint8_t* sampleData = frameData + c * bytesPerSample;
+                if (BitsPerSample == 16) {
+                    int16_t val = (int16_t)ReadLE16(sampleData);
+                    out[c] = (float)val / 32768.0f;
+                } else if (BitsPerSample == 24) {
+                    int32_t val = (int32_t)(sampleData[0] | (sampleData[1] << 8) | (sampleData[2] << 16));
+                    if (val & 0x800000) val |= 0xFF000000; // sign extend
+                    out[c] = (float)val / 8388608.0f;
+                } else if (BitsPerSample == 32) {
+                    int32_t val = (int32_t)ReadLE32(sampleData);
+                    out[c] = (float)val / 2147483648.0f;
+                } else {
+                    out[c] = 0.0f;
+                }
+            }
+        }
+
+        return nRead;
+    }
+
+    size_t Write(const TPCMBuffer& /*buf*/, size_t /*sz*/) override {
+        // Read-only backend
+        return 0;
+    }
+
+private:
+    void ParseHeader() {
+        uint8_t header[12];
+        if (fread(header, 1, 12, Fp) != 12) {
+            throw std::runtime_error("invalid WAV file: too short");
+        }
+
+        if (memcmp(header, "RIFF", 4) != 0) {
+            throw std::runtime_error("invalid WAV file: missing RIFF marker");
+        }
+        if (memcmp(header + 8, "WAVE", 4) != 0) {
+            throw std::runtime_error("invalid WAV file: missing WAVE marker");
+        }
+
+        bool foundFmt = false;
+        bool foundData = false;
+
+        while (!foundData) {
+            uint8_t chunkHeader[8];
+            if (fread(chunkHeader, 1, 8, Fp) != 8) break;
+
+            uint32_t chunkSize = ReadLE32(chunkHeader + 4);
+
+            if (memcmp(chunkHeader, "fmt ", 4) == 0) {
+                // Parse format chunk
+                std::vector<uint8_t> fmtData(chunkSize);
+                if (fread(fmtData.data(), 1, chunkSize, Fp) != chunkSize) {
+                    throw std::runtime_error("invalid WAV file: truncated fmt chunk");
+                }
+
+                uint16_t audioFormat = ReadLE16(fmtData.data());
+                if (audioFormat != 1 && audioFormat != 3) { // PCM or IEEE float
+                    throw std::runtime_error("unsupported WAV format: only PCM (1) and IEEE float (3) are supported");
+                }
+
+                Channels = ReadLE16(fmtData.data() + 2);
+                SampleRate = ReadLE32(fmtData.data() + 4);
+                BitsPerSample = ReadLE16(fmtData.data() + 14);
+
+                if (Channels == 0 || SampleRate == 0 || BitsPerSample == 0) {
+                    throw std::runtime_error("invalid WAV format parameters");
+                }
+
+                foundFmt = true;
+            } else if (memcmp(chunkHeader, "data", 4) == 0) {
+                if (!foundFmt) {
+                    throw std::runtime_error("invalid WAV file: data chunk before fmt chunk");
+                }
+
+                DataOffset = ftell(Fp);
+                DataSize = chunkSize;
+                TotalSamples = DataSize / (Channels * (BitsPerSample / 8));
+
+                foundData = true;
+            } else {
+                // Skip unknown chunk
+                if (chunkSize > 0) {
+                    fseek(Fp, chunkSize, SEEK_CUR);
+                }
+            }
+        }
+
+        if (!foundFmt || !foundData) {
+            throw std::runtime_error("invalid WAV file: missing fmt or data chunk");
+        }
+    }
+
+    FILE* Fp;
+    size_t Channels;
+    size_t SampleRate;
+    size_t TotalSamples;
+    size_t BitsPerSample;
+    long DataOffset;
+    size_t DataSize;
+    size_t BytesRead;
+};
+
+class TPCMIOWavBuiltinWriter : public IPCMProviderImpl {
+public:
+    TPCMIOWavBuiltinWriter(const std::string& filename, int channels, int sampleRate)
+        : Fp(nullptr)
+        , Channels(channels)
+        , SampleRate(sampleRate)
+        , TotalSamples(0)
+        , DataSize(0)
+    {
+        Fp = NAtracDEnc::FOpenUtf8(filename, "wb");
+        if (!Fp) {
+            throw std::runtime_error("unable to open output file '" + filename + "'");
+        }
+        WriteHeader();
+    }
+
+    ~TPCMIOWavBuiltinWriter() {
+        if (Fp) {
+            Finalize();
+            fclose(Fp);
+        }
+    }
+
+    size_t GetChannelsNum() const override { return Channels; }
+    size_t GetSampleRate() const override { return SampleRate; }
+    size_t GetTotalSamples() const override { return TotalSamples; }
+
+    size_t Read(TPCMBuffer&, size_t) override { return 0; }
+
+    size_t Write(const TPCMBuffer& buf, size_t sz) override {
+        if (!Fp) return 0;
+
+        const size_t frameBytes = Channels * 2; // 16-bit
+        std::vector<uint8_t> rawBuf(sz * frameBytes);
+
+        for (size_t i = 0; i < sz; i++) {
+            const float* in = buf[i];
+            uint8_t* frameData = rawBuf.data() + i * frameBytes;
+            for (size_t c = 0; c < Channels; c++) {
+                float sample = in[c];
+                if (sample > 1.0f) sample = 1.0f;
+                if (sample < -1.0f) sample = -1.0f;
+                int16_t val = (int16_t)(sample * 32767.0f);
+                frameData[c * 2] = (uint8_t)(val & 0xFF);
+                frameData[c * 2 + 1] = (uint8_t)((val >> 8) & 0xFF);
+            }
+        }
+
+        size_t written = fwrite(rawBuf.data(), frameBytes, sz, Fp);
+        DataSize += written * frameBytes;
+        TotalSamples += written;
+        return written;
+    }
+
+private:
+    void WriteHeader() {
+        // Write placeholder header
+        uint8_t header[44] = {};
+        memcpy(header, "RIFF", 4);
+        memcpy(header + 8, "WAVE", 4);
+        memcpy(header + 12, "fmt ", 4);
+        uint32_t fmtSize = 16;
+        memcpy(header + 16, &fmtSize, 4);
+        uint16_t audioFormat = 1; // PCM
+        memcpy(header + 20, &audioFormat, 2);
+        uint16_t ch = (uint16_t)Channels;
+        memcpy(header + 22, &ch, 2);
+        uint32_t sr = (uint32_t)SampleRate;
+        memcpy(header + 24, &sr, 4);
+        uint32_t byteRate = (uint32_t)(SampleRate * Channels * 2);
+        memcpy(header + 28, &byteRate, 4);
+        uint16_t blockAlign = (uint16_t)(Channels * 2);
+        memcpy(header + 32, &blockAlign, 2);
+        uint16_t bps = 16;
+        memcpy(header + 34, &bps, 2);
+        memcpy(header + 36, "data", 4);
+        fwrite(header, 1, 44, Fp);
+    }
+
+    void Finalize() {
+        uint32_t fileSize = (uint32_t)(DataSize + 36);
+        fseek(Fp, 4, SEEK_SET);
+        fwrite(&fileSize, 4, 1, Fp);
+        fseek(Fp, 40, SEEK_SET);
+        uint32_t ds = (uint32_t)DataSize;
+        fwrite(&ds, 4, 1, Fp);
+    }
+
+    FILE* Fp;
+    size_t Channels;
+    size_t SampleRate;
+    size_t TotalSamples;
+    size_t DataSize;
+};
+
+IPCMProviderImpl* CreatePCMIOReadImpl(const std::string& path) {
+    return new TPCMIOWavBuiltin(path);
+}
+
+IPCMProviderImpl* CreatePCMIOWriteImpl(const std::string& path, int channels, int sampleRate) {
+    return new TPCMIOWavBuiltinWriter(path, channels, sampleRate);
+}

--- a/src/resampler.cpp
+++ b/src/resampler.cpp
@@ -1,0 +1,249 @@
+/*
+ * High-quality polyphase resampler for PCM audio.
+ * Uses a windowed-sinc (Blackman) lowpass filter for clean conversion.
+ *
+ * This file is part of AtracDEnc.
+ *
+ * AtracDEnc is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+
+#include "resampler.h"
+
+#include <cmath>
+#include <cstring>
+#include <algorithm>
+#include <stdexcept>
+#include <vector>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+// --------------------------------------------------------------------------
+// Windowed-sinc resampler (polyphase)
+// --------------------------------------------------------------------------
+
+class CResamplerReader : public IPCMReader {
+public:
+    CResamplerReader(std::unique_ptr<IPCMReader> src,
+                     uint32_t srcRate, uint32_t dstRate,
+                     uint16_t channels)
+        : Src(std::move(src))
+        , Channels(channels)
+        , SrcRate(srcRate)
+        , DstRate(dstRate)
+        , Ratio((double)srcRate / (double)dstRate)
+        , PhaseCount(0)
+        , FilterLen(0)
+        , SrcBufPos(0)
+        , SrcBufUsed(0)
+        , FracPos(0.0)
+        , SrcExhausted(false)
+    {
+        if (!Src)
+            throw std::invalid_argument("resampler: null source reader");
+        if (srcRate == 0 || dstRate == 0)
+            throw std::invalid_argument("resampler: sample rate must be > 0");
+        if (srcRate == dstRate)
+            throw std::invalid_argument("resampler: rates are equal, no resampling needed");
+
+        // Choose filter parameters based on the conversion ratio
+        // More phases = better quality, but more memory
+        PhaseCount = 256;
+        // Filter half-length (in input samples); longer = sharper cutoff
+        HalfLen = 32;
+        FilterLen = 2 * HalfLen;
+
+        BuildFilter();
+
+        // Internal source buffer: must hold enough input for a batch of output samples
+        // We read in chunks to avoid excessive per-sample reads
+        SrcBuf.resize(SrcBufSize * Channels, 0.0f);
+    }
+
+    bool Read(TPCMBuffer& outBuf, const uint32_t outFrames) const override {
+        const uint16_t ch = Channels;
+        uint32_t written = 0;
+
+        while (written < outFrames) {
+            // Refill source buffer if running low and source not exhausted
+            if (!SrcExhausted && SrcBufPos + (size_t)FilterLen > SrcBufUsed) {
+                // Shift remaining samples to front
+                size_t remain = (SrcBufPos < SrcBufUsed) ? (SrcBufUsed - SrcBufPos) : 0;
+                if (remain > 0 && SrcBufPos > 0) {
+                    memmove(SrcBuf.data(),
+                            SrcBuf.data() + SrcBufPos * ch,
+                            remain * ch * sizeof(float));
+                }
+                SrcBufUsed = remain;
+                SrcBufPos = 0;
+
+                // Read more data from source
+                uint32_t toRead = (uint32_t)(SrcBufSize - SrcBufUsed);
+                if (toRead > 0) {
+                    TPCMBuffer tmpBuf((uint16_t)toRead, ch);
+                    bool ok = Src->Read(tmpBuf, toRead);
+                    if (!ok) {
+                        SrcExhausted = true;
+                        // Zero-pad the remaining source buffer so the filter can still run
+                        if (SrcBufUsed < (size_t)FilterLen) {
+                            memset(SrcBuf.data() + SrcBufUsed * ch, 0,
+                                   (FilterLen - SrcBufUsed) * ch * sizeof(float));
+                            SrcBufUsed = FilterLen;
+                        }
+                    } else {
+                        for (uint32_t i = 0; i < toRead; i++) {
+                            for (uint16_t c = 0; c < ch; c++) {
+                                SrcBuf[(SrcBufUsed + i) * ch + c] = tmpBuf[i][c];
+                            }
+                        }
+                        SrcBufUsed += toRead;
+                    }
+                }
+            }
+
+            // Check if we have enough data to produce an output sample
+            if (SrcBufPos + (size_t)FilterLen > SrcBufUsed) {
+                // Not enough source data even after refill attempt
+                if (SrcExhausted) {
+                    // Pad output with zeros to let PQF drain
+                    for (uint32_t i = written; i < outFrames; i++) {
+                        for (uint16_t c = 0; c < ch; c++) {
+                            outBuf[i][c] = 0.0f;
+                        }
+                    }
+                    return true;
+                }
+                break;
+            }
+
+            // Resample one output sample using polyphase sinc interpolation
+            size_t intPos = SrcBufPos;
+            double frac = FracPos;
+
+            int phase = (int)(frac * PhaseCount + 0.5);
+            if (phase >= PhaseCount) phase = PhaseCount - 1;
+
+            for (uint16_t c = 0; c < ch; c++) {
+                double sum = 0.0;
+                for (int k = 0; k < FilterLen; k++) {
+                    size_t srcIdx = intPos + k;
+                    if (srcIdx < SrcBufUsed) {
+                        sum += SrcBuf[srcIdx * ch + c] * FilterBank[phase * FilterLen + k];
+                    }
+                }
+                outBuf[written][c] = (float)sum;
+            }
+            written++;
+
+            // Advance source position
+            FracPos += Ratio;
+            size_t advance = (size_t)FracPos;
+            FracPos -= advance;
+            SrcBufPos += advance;
+        }
+
+        return written > 0;
+    }
+
+private:
+    void BuildFilter() {
+        FilterBank.resize((size_t)PhaseCount * FilterLen);
+
+        for (int p = 0; p < PhaseCount; p++) {
+            double phaseOffset = (double)p / PhaseCount;
+            double sum = 0.0;
+
+            for (int k = 0; k < FilterLen; k++) {
+                // Position relative to the interpolation point
+                double x = (k - HalfLen + 1) + phaseOffset;
+
+                // Windowed sinc
+                double w;
+                double sincVal;
+
+                if (fabs(x) < 1e-10) {
+                    sincVal = 1.0;
+                } else {
+                    sincVal = sin(M_PI * x) / (M_PI * x);
+                }
+
+                // Blackman window
+                double n = (double)k / (FilterLen - 1);
+                w = 0.42 - 0.5 * cos(2.0 * M_PI * n) + 0.08 * cos(4.0 * M_PI * n);
+
+                double val = sincVal * w;
+                FilterBank[p * FilterLen + k] = (float)val;
+                sum += val;
+            }
+
+            // Normalize so the filter has unity gain
+            if (fabs(sum) > 1e-10) {
+                float scale = (float)(1.0 / sum);
+                for (int k = 0; k < FilterLen; k++) {
+                    FilterBank[p * FilterLen + k] *= scale;
+                }
+            }
+        }
+    }
+
+    std::unique_ptr<IPCMReader> Src;
+    uint16_t Channels;
+    uint32_t SrcRate;
+    uint32_t DstRate;
+    double Ratio;
+
+    int PhaseCount;
+    int HalfLen;
+    int FilterLen;
+    std::vector<float> FilterBank;
+
+    // Internal interleaved source buffer
+    static const size_t SrcBufSize = 4096;
+    mutable std::vector<float> SrcBuf;
+    mutable size_t SrcBufPos;
+    mutable size_t SrcBufUsed;
+    mutable double FracPos;
+    mutable bool SrcExhausted;
+};
+
+// --------------------------------------------------------------------------
+// Pass-through reader (same rate, no resampling needed)
+// --------------------------------------------------------------------------
+
+class CPassThroughReader : public IPCMReader {
+public:
+    CPassThroughReader(std::unique_ptr<IPCMReader> src)
+        : Src(std::move(src)) {}
+
+    bool Read(TPCMBuffer& buf, const uint32_t size) const override {
+        return Src->Read(buf, size);
+    }
+
+private:
+    std::unique_ptr<IPCMReader> Src;
+};
+
+// --------------------------------------------------------------------------
+// Public API
+// --------------------------------------------------------------------------
+
+std::unique_ptr<IPCMReader> CreateResamplingReader(
+    std::unique_ptr<IPCMReader> input,
+    uint32_t srcRate,
+    uint32_t dstRate,
+    uint16_t channels)
+{
+    if (srcRate == dstRate) {
+        return std::make_unique<CPassThroughReader>(std::move(input));
+    }
+    return std::make_unique<CResamplerReader>(std::move(input), srcRate, dstRate, channels);
+}
+
+uint64_t ResampledLength(uint64_t srcSamples, uint32_t srcRate, uint32_t dstRate) {
+    if (srcRate == dstRate) return srcSamples;
+    return (uint64_t)((double)srcSamples * dstRate / srcRate + 0.5);
+}

--- a/src/resampler.h
+++ b/src/resampler.h
@@ -1,0 +1,39 @@
+/*
+ * High-quality polyphase resampler for PCM audio.
+ * Uses a windowed-sinc (Blackman) lowpass filter for clean conversion.
+ *
+ * This file is part of AtracDEnc.
+ *
+ * AtracDEnc is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+
+#pragma once
+
+#include "pcmengin.h"
+#include <cstdint>
+#include <memory>
+#include <cstddef>
+
+/**
+ * Resample a TPCMBuffer stream from srcRate to dstRate using windowed-sinc
+ * (Blackman) polyphase interpolation.
+ *
+ * @param input       Reader providing samples at srcRate
+ * @param srcRate     Source sample rate in Hz
+ * @param dstRate     Target sample rate in Hz (default 44100)
+ * @param channels    Number of audio channels
+ * @return            A new IPCMReader that delivers resampled audio at dstRate
+ */
+std::unique_ptr<IPCMReader> CreateResamplingReader(
+    std::unique_ptr<IPCMReader> input,
+    uint32_t srcRate,
+    uint32_t dstRate,
+    uint16_t channels);
+
+/**
+ * Compute the total number of output samples after resampling.
+ */
+uint64_t ResampledLength(uint64_t srcSamples, uint32_t srcRate, uint32_t dstRate);

--- a/src/transient_spectral_upsampler.cpp
+++ b/src/transient_spectral_upsampler.cpp
@@ -82,73 +82,42 @@ TProcessResult TSpectralUpsampler::Process(const float* in) const
         windowed[n] = in[n] * Win[n];
 
     // 2. Forward real FFT: kInN real → kInN/2+1 complex bins.
-    const int kInBins = kInN / 2 + 1;  // 257
+    constexpr int kInBins = kInN / 2 + 1;  // 257
     std::vector<kiss_fft_cpx> fwdOut(kInBins);
     kiss_fftr(static_cast<kiss_fftr_cfg>(FwdCfg), windowed.data(), fwdOut.data());
 
     // 2a. Filtered high-frequency energy ratio.
-    //
-    //     highFreqRatio = sum(|X[k] * H[k]|²) / sum(|X[k]|²)
-    //
-    //     H[k] is the same 5-bin raised-cosine HPF applied in step 3.
-    //     Weighting by H[k]² (energy after filtering) ensures that content
-    //     near but below the cutoff—where H[k] ≈ 0—contributes negligibly,
-    //     even though the raw bin energy may be significant.  Near 0 when the
-    //     frame is sub-cutoff dominated; near 1 in the passband.
-    //     Callers should skip CalcCurve when this is below kHighFreqThreshold.
     double totalE = 0.0, filtHighE = 0.0;
     for (int k = 0; k <= kInN / 2; ++k) {
         const double e = static_cast<double>(fwdOut[k].r) * fwdOut[k].r
                        + static_cast<double>(fwdOut[k].i) * fwdOut[k].i;
         totalE += e;
-        // Compute H[k] (same formula as step 3).
         float H = 0.0f;
         if (LowCutBin == 0) {
             H = 1.0f;
         } else if (k >= LowCutBin + 2) {
             H = 1.0f;
         } else if (k >= LowCutBin) {
-            const int i = k - LowCutBin + 1;  // i in [1..2]
+            const int i = k - LowCutBin + 1;
             H = 0.5f * (1.0f - std::cos(static_cast<float>(M_PI) * i / 2.0f));
         }
-        // else k < LowCutBin: H = 0 (stopband)
         filtHighE += e * H * H;
     }
     const float highFreqRatio = (totalE > 0.0)
                               ? static_cast<float>(filtHighE / totalE) : 0.0f;
 
     // 3. Build the kOutN/2+1 frequency-domain input for the inverse FFT.
-    //
-    //    Upsampling by kUpsample in the frequency domain, with a 3-bin
-    //    raised-cosine high-pass filter H[k] = 0.5*(1 - cos(π·i/2)):
-    //
-    //      k = LowCutBin - 1 (i=0): H = 0.000  (stopband)
-    //      k = LowCutBin     (i=1): H = 0.500  (transition)
-    //      k = LowCutBin + 1 (i=2): H = 1.000  (passband start)
-    //      k >= LowCutBin + 2:       H = 1.0                        (passband)
-    //      k < LowCutBin:            H = 0                          (stopband)
-    //
-    //    When LowCutBin == 0 the transition is skipped and all bins are passed.
-    //
-    //      Y[k] = kUpsample * X[k] * H[k]   for k in [0, kInN/2)
-    //      Y[kInN/2] = kUpsample/2 * X[kInN/2].r * H[kInN/2]  (Nyquist)
-    //      Y[k] = 0  for k in [kInN/2+1, kOutN/2]  (zero-padding)
-    //
-    //    After kiss_fftri (which returns kOutN * IFFT(Y)), dividing by kOutN
-    //    yields amplitudes equal to those of the original windowed signal.
-    const int kOutBins = kOutN / 2 + 1;  // 2049
+    constexpr int kOutBins = kOutN / 2 + 1;  // 2049
     std::vector<kiss_fft_cpx> invIn(kOutBins, {0.0f, 0.0f});
 
     const float scale = static_cast<float>(kUpsample);
 
-    // Full passband bins (above the transition, or all bins when no cut).
+    // Full passband bins
     const int passbandStart = (LowCutBin == 0) ? 0 : LowCutBin + 2;
     for (int k = passbandStart; k < kInN / 2; ++k)
         invIn[k] = {fwdOut[k].r * scale, fwdOut[k].i * scale};
 
-    // 3-bin raised-cosine transition: H[i] = 0.5*(1 - cos(π·i/2)), i in [0..2].
-    // i=0 (LowCutBin-1) stays zero; i=1 → H=0.5, i=2 → H=1.0 (passband start).
-    // Skipped entirely when LowCutBin == 0 (no cut).
+    // 3-bin raised-cosine transition
     if (LowCutBin > 0) {
         for (int i = 1; i < 3; ++i) {
             const int k = LowCutBin - 1 + i;
@@ -158,25 +127,53 @@ TProcessResult TSpectralUpsampler::Process(const float* in) const
         }
     }
 
-    // Nyquist bin of the original kInN-point FFT (purely real).
-    // Halved so that its contribution from the positive and negative sides
-    // of the kOutN-point spectrum sums to the correct amplitude.
-    // Apply the same H[kInN/2] as any other passband bin (almost always 1).
+    // Nyquist bin
     if (LowCutBin + 2 <= kInN / 2)
         invIn[kInN / 2] = {fwdOut[kInN / 2].r * scale * 0.5f, 0.0f};
-
-    // Bins [kInN/2+1 .. kOutBins-1] remain zero (zero-padding).
 
     // 4. Inverse real FFT: kOutBins complex → kOutN real.
     std::vector<float> output(kOutN);
     kiss_fftri(static_cast<kiss_fftr_cfg>(InvCfg), invIn.data(), output.data());
 
-    // 5. Normalize: kiss_fftri is unnormalized (output = kOutN * IFFT(input)).
+    // 5. Normalize
     const float norm = 1.0f / static_cast<float>(kOutN);
     for (float& v : output)
         v *= norm;
 
     return TProcessResult{std::move(output), highFreqRatio};
+}
+
+// ===== 性能优化：只计算highFreqRatio，跳过昂贵的4096点IFFT =====
+float TSpectralUpsampler::CalcHighFreqRatio(const float* in) const
+{
+    // 1. Apply Planck-taper window.
+    float windowed[kInN];
+    for (int n = 0; n < kInN; ++n)
+        windowed[n] = in[n] * Win[n];
+
+    // 2. Forward real FFT: kInN real → kInN/2+1 complex bins.
+    constexpr int kInBins = kInN / 2 + 1;
+    kiss_fft_cpx fwdOut[kInBins];
+    kiss_fftr(static_cast<kiss_fftr_cfg>(FwdCfg), windowed, fwdOut);
+
+    // 3. Compute high-frequency energy ratio.
+    double totalE = 0.0, filtHighE = 0.0;
+    for (int k = 0; k <= kInN / 2; ++k) {
+        const double e = static_cast<double>(fwdOut[k].r) * fwdOut[k].r
+                       + static_cast<double>(fwdOut[k].i) * fwdOut[k].i;
+        totalE += e;
+        float H = 0.0f;
+        if (LowCutBin == 0) {
+            H = 1.0f;
+        } else if (k >= LowCutBin + 2) {
+            H = 1.0f;
+        } else if (k >= LowCutBin) {
+            const int i = k - LowCutBin + 1;
+            H = 0.5f * (1.0f - std::cos(static_cast<float>(M_PI) * i / 2.0f));
+        }
+        filtHighE += e * H * H;
+    }
+    return (totalE > 0.0) ? static_cast<float>(filtHighE / totalE) : 0.0f;
 }
 
 } // namespace NAtracDEnc

--- a/src/transient_spectral_upsampler.h
+++ b/src/transient_spectral_upsampler.h
@@ -82,6 +82,10 @@ public:
     // Returns the upsampled signal and its high-frequency energy ratio.
     TProcessResult Process(const float* in) const;
 
+    // 只计算highFreqRatio（只做512点前向FFT，跳过4096点逆FFT）
+    // 当ratio低于阈值时，可以跳过昂贵的Process()调用
+    float CalcHighFreqRatio(const float* in) const;
+
 private:
     const int          LowCutBin;  // first kept bin (inclusive); bins [0,LowCutBin) are zeroed
     std::vector<float> Win;

--- a/src/transient_spectral_upsampler.h
+++ b/src/transient_spectral_upsampler.h
@@ -82,8 +82,6 @@ public:
     // Returns the upsampled signal and its high-frequency energy ratio.
     TProcessResult Process(const float* in) const;
 
-    // 只计算highFreqRatio（只做512点前向FFT，跳过4096点逆FFT）
-    // 当ratio低于阈值时，可以跳过昂贵的Process()调用
     float CalcHighFreqRatio(const float* in) const;
 
 private:


### PR DESCRIPTION
Added support for encoding ATRAC3 and ATRAC3plus into RIFF container format (.at3). Optimized encoding speed: minor improvement for ATRAC3, significant improvement for ATRAC3plus. Removed WAV input restrictions. We should provide convenience to users rather than forcing them to use 44100 Hz WAV files. Although 44100 Hz is the official standard, we now support WAV files with any sample rate. If the input sample rate is not 44100 Hz, it will be automatically resampled before encoding. This way, users no longer need to manually convert their audio to 44100 Hz WAV.