### PR TITLE
atrac1: use a constant bit allocation spread

### DIFF
--- a/src/atrac/at1/atrac1_bitalloc.cpp
+++ b/src/atrac/at1/atrac1_bitalloc.cpp
@@ -45,6 +45,20 @@ static const float FixedBitAllocTableShort[TAtrac1Data::MaxBfus] = {
     4, 4, 4, 4, 4, 4, 4, 4,   0, 0, 0, 0, 0, 0, 0, 0
 };
 
+// Blend between signal-adaptive and fixed-table bit allocation (see
+// CalcBitsAllocation). AnalizeScaleFactorSpread() derives this from the standard
+// deviation of the scale factor indices, but on ATRAC1 that measures worse than a
+// constant across the EBU SQAM corpus: the heuristic drives spread towards 1 on
+// sparse/tonal material, making allocation nearly proportional to band energy and
+// starving quiet bands that have no loud neighbour to mask them.
+//
+// Mean noise-to-mask ratio over the 70-track corpus (lower is better):
+//   heuristic -13.09 dB | 0.30 -13.72 | 0.35 -13.75 | 0.40 -13.76 | 0.45 -13.73
+// and clamping the heuristic rather than replacing it is worse the wider the
+// clamp, so the optimum is broad and the statistic itself is not carrying signal.
+// ATRAC3 still uses AnalizeScaleFactorSpread(); it was not evaluated here.
+static constexpr float BitAllocSpread = 0.4f;
+
 static const uint32_t BitBoostMask[TAtrac1Data::MaxBfus] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1,
     1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1,
@@ -336,7 +350,7 @@ uint32_t TAt1BitAlloc::Write(const std::vector<TScaledBlock>& scaledBlocks, cons
         blockSize,
         loudness,
         bfuIdx,
-        AnalizeScaleFactorSpread(scaledBlocks),
+        BitAllocSpread,
         bitsPerEachBlock,
     };
 


### PR DESCRIPTION
`CalcBitsAllocation()` blends signal-adaptive and fixed-table allocation using a `spread` value from `AnalizeScaleFactorSpread()`, which derives it from the standard deviation of the scale factor indices. Measuring on the 70-track EBU SQAM corpus, that heuristic performs worse than simply using a constant.

On sparse or tonal material the scale factors vary widely, so the heuristic returns a value near 1 and allocation becomes nearly proportional to band energy. That starves quiet bands — which are exactly the ones with no loud neighbour to mask their quantisation noise.

Mean noise-to-mask ratio over the corpus (lower is better):

| spread | mean NMR |
|---|---|
| heuristic (current) | −13.09 dB |
| 0.30 | −13.72 |
| 0.35 | −13.75 |
| **0.40** | **−13.76** |
| 0.45 | −13.73 |
| 0.00 (fixed table only) | −9.89 |
| 1.00 (fully adaptive) | −12.01 |

0.40 improves 57 of 70 tracks and regresses 4, the worst by 1.14 dB. The optimum is broad, so the exact value isn't critical.

Clamping the heuristic into a range rather than replacing it is worse the wider the clamp, and two clamps of equal width but different centres score identically (−13.478 / −13.479) — width matters, centre doesn't. That suggests the statistic isn't carrying usable signal for this decision, rather than merely being mis-scaled.

### Scope

Applied at the ATRAC1 call site only. `AnalizeScaleFactorSpread()` is also used by ATRAC3 (`atrac3_bitstream.cpp:602`) and is left untouched — I couldn't evaluate ATRAC3 meaningfully, since it decodes at ~2.5 dB waveform SNR (the spectrum matches the reference within ~1 dB to 16 kHz, so nothing is broken — it simply doesn't preserve waveform phase at 132 kbps, which puts any allocation change below the noise floor of a waveform-difference metric).

### On the metric

I used noise-to-mask ratio rather than PEAQ. I started with `peaqb-fast` and found it unusable here: injecting white noise at known SNR, it is monotonic on broadband material but inverts on tonal material — 75 dB-SNR noise against a pure tone scores −2.2 ODG and it saturates near −3.9 by 45 dB. Across this corpus its ODG *anti-correlated* with SNR (r = −0.65).

The NMR implementation is my own (MPEG-style masking model: Hann FFT, Bark banding, Schroeder spreading, SFM tonality offset, ATH floor; aggregated as the mean per-band-frame ratio of error power to masking threshold). It passes the same noise-injection calibration monotonically on both broadband and tonal signals. It is not a reference tool and I'd encourage checking it — happy to share the script and the calibration harness.

Unit tests pass (22/22).
