### PR TITLE
atrac1: shift allocation upwards on low-heavy spectra

### DIFF
--- a/src/atrac/at1/atrac1_bitalloc.cpp
+++ b/src/atrac/at1/atrac1_bitalloc.cpp
@@ -45,6 +45,20 @@ static const float FixedBitAllocTableShort[TAtrac1Data::MaxBfus] = {
     4, 4, 4, 4, 4, 4, 4, 4,   0, 0, 0, 0, 0, 0, 0, 0
 };
 
+// Blend between signal-adaptive and fixed-table bit allocation (see
+// CalcBitsAllocation). AnalizeScaleFactorSpread() derives this from the standard
+// deviation of the scale factor indices, but on ATRAC1 that measures worse than a
+// constant across the EBU SQAM corpus: the heuristic drives spread towards 1 on
+// sparse/tonal material, making allocation nearly proportional to band energy and
+// starving quiet bands that have no loud neighbour to mask them.
+//
+// Mean noise-to-mask ratio over the 70-track corpus (lower is better):
+//   heuristic -13.09 dB | 0.30 -13.72 | 0.35 -13.75 | 0.40 -13.76 | 0.45 -13.73
+// and clamping the heuristic rather than replacing it is worse the wider the
+// clamp, so the optimum is broad and the statistic itself is not carrying signal.
+// ATRAC3 still uses AnalizeScaleFactorSpread(); it was not evaluated here.
+static constexpr float BitAllocSpread = 0.4f;
+
 static const uint32_t BitBoostMask[TAtrac1Data::MaxBfus] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1,
     1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1,
@@ -336,7 +350,7 @@ uint32_t TAt1BitAlloc::Write(const std::vector<TScaledBlock>& scaledBlocks, cons
         blockSize,
         loudness,
         bfuIdx,
-        AnalizeScaleFactorSpread(scaledBlocks),
+        BitAllocSpread,
         bitsPerEachBlock,
     };
 

--- a/src/atrac/at1/atrac1_bitalloc.cpp
+++ b/src/atrac/at1/atrac1_bitalloc.cpp
@@ -21,6 +21,7 @@
 #include <atrac/atrac_psy_common.h>
 #include <atrac/atrac_scale.h>
 #include <math.h>
+#include <algorithm>
 #include <cassert>
 #include <bitstream/bitstream.h>
 #include <env.h>
@@ -133,6 +134,32 @@ void CalcAt1ATH() noexcept {
     }
 }
 
+// Bias applied to the middle and high QMF bands, scaled by how low-heavy the
+// spectrum is. Tuned on the EBU SQAM corpus; see the comment in
+// CalcBitsAllocation() and the commit message.
+static constexpr float BandBiasGain = 0.3f;       // per unit of tilt
+static constexpr float BandBiasTiltFloor = 7.0f;  // no bias below this tilt
+static constexpr float BandBiasMax = 1.5f;        // cap, see gong regression
+static constexpr float BandBiasHighRatio = 0.5f;  // high band gets half of it
+
+// Mean scale factor index of the low band minus that of the middle band: a cheap
+// measure of how much of the energy sits below 5.5 kHz.
+static float CalcLowToMidTilt(const std::vector<TScaledBlock>& scaledBlocks,
+                              const uint32_t bfuNum) noexcept {
+    float sumLow = 0.0f, sumMid = 0.0f;
+    uint32_t nLow = 0, nMid = 0;
+    for (size_t i = 0; i < bfuNum; ++i) {
+        switch (TAtrac1Data::BfuToBand(i)) {
+            case 0: sumLow += scaledBlocks[i].ScaleFactorIndex; nLow++; break;
+            case 1: sumMid += scaledBlocks[i].ScaleFactorIndex; nMid++; break;
+            default: break;
+        }
+    }
+    if (!nLow || !nMid)
+        return 0.0f;
+    return sumLow / nLow - sumMid / nMid;
+}
+
 static vector<uint32_t> CalcBitsAllocation(const std::vector<TScaledBlock>& scaledBlocks,
                                            const uint32_t bfuNum,
                                            const float spread,
@@ -140,6 +167,21 @@ static vector<uint32_t> CalcBitsAllocation(const std::vector<TScaledBlock>& scal
                                            const TAtrac1Data::TBlockSizeMod& blockSize,
                                            const float loudness) noexcept {
     vector<uint32_t> bitsPerEachBlock(bfuNum);
+
+    // Sustained tonal material (woodwinds, bowed strings) leaves the low band far
+    // below the masking threshold while 8-11 kHz is audibly starved: those BFUs
+    // end up with a word length near zero in 40-49% of frames. Shift a little of
+    // the allocation upwards when the spectrum is low-heavy.
+    //
+    // A constant bias does not work -- it helps tonal material and costs
+    // spectrally flat material about as much, because percussion has no spare
+    // margin in the low band to give away. Scaling it by how low-heavy the
+    // spectrum is avoids that; the tilt is derived from data already to hand.
+    const float tilt = CalcLowToMidTilt(scaledBlocks, bfuNum);
+    const float midBias = std::min(BandBiasMax,
+                                   BandBiasGain * std::max(0.0f, tilt - BandBiasTiltFloor));
+    const float bandBias[TAtrac1Data::NumQMF] = {0.0f, midBias, midBias * BandBiasHighRatio};
+
     for (size_t i = 0; i < bitsPerEachBlock.size(); ++i) {
         bool shortBlock = blockSize.LogCount[TAtrac1Data::BfuToBand(i)];
         const float fix = shortBlock ? FixedBitAllocTableShort[i] : FixedBitAllocTableLong[i];
@@ -148,7 +190,8 @@ static vector<uint32_t> CalcBitsAllocation(const std::vector<TScaledBlock>& scal
         if (!shortBlock && scaledBlocks[i].Energy < ath) {
             bitsPerEachBlock[i] = 0;
         } else {
-            int tmp = spread * ( (float)scaledBlocks[i].ScaleFactorIndex/3.2f) + (1.0f - spread) * fix - shift;
+            int tmp = spread * ( (float)scaledBlocks[i].ScaleFactorIndex/3.2f) + (1.0f - spread) * fix - shift
+                    + bandBias[TAtrac1Data::BfuToBand(i)];
             if (tmp > 16) {
                 bitsPerEachBlock[i] = 16;
             } else if (tmp < 2) {


### PR DESCRIPTION
> Stacked on #81 — the first of the two commits here is that PR. Review/merge that one first; this branch will rebase cleanly.

On sustained tonal material — woodwinds, bowed strings — almost all audible quantisation noise sits in the middle QMF band. Noise measured against a masking threshold, per band, on cor anglais:

| band | NMR | band-frames above threshold |
|---|---|---|
| 0–500 Hz | −28.4 dB | 0.0% |
| 500–1500 | −30.4 | 0.0% |
| 1500–3000 | −23.4 | 0.0% |
| 3000–5500 | −16.2 | 0.0% |
| 5500–8000 | −3.3 | 22.3% |
| 8000–11000 | **+3.0** | **58.9%** |

The low band runs ~28 dB below threshold — carrying far more precision than it needs — while BFUs 29–35 are given a word length near zero in 40–49% of frames. It's a distribution problem, not a bit shortage.

A constant bias towards the mid/high bands doesn't help overall: it gains ~0.9 dB on tonal material and loses ~1.0 dB on spectrally flat material, because percussion has no spare margin in the low band to give away. Scaling the bias by how low-heavy the spectrum is avoids that. The tilt measure (mean scale factor index of the low band minus the mid band) comes from data already in hand.

Mean noise-to-mask ratio over the 70-track EBU SQAM corpus:

| | before | after |
|---|---|---|
| woodwind/string (8 tracks) | −7.60 dB | **−8.47** |
| remainder (62) | −14.56 | **−14.79** |
| all 70 | −13.76 | **−14.07** |

43 of 70 improve, 4 regress. Per-track gains on affected material: bass clarinet 3.89 dB, viola 2.64, cor anglais 2.47, violin 1.73.

### The regression

The gong regresses by 1.95 dB — its spectrum is extremely low-heavy, so it earns a large bias it can't use. The cap limits that but doesn't remove it. Triangle (+0.36), cymbal (+0.13) and marimba (+0.10) are the other three.

The tilt is an empirical proxy for "does the low band have margin to spare". A direct per-band margin estimate would be more principled, but needs a masking model the encoder doesn't currently have. I'd be glad of a better suggestion here — this is the weakest part of the change.

### Listening check

Small blind A/B on a Sony MZ-N920, using the factory-mode SP upload so the encoder's bitstream is stored verbatim (verified bit-exact on readback, so the device's own encoder is out of the path). Four pairs, stock vs both patches, assignment randomised per pair and the key withheld until judged.

The listener picked the tuned encode 4/4, describing it as "more atmospheric"/"more expansive" versus "cleaner/duller". The one pair with a flipped assignment flipped their answer too, so it isn't position bias. Objectively, in 5.5–11 kHz the tuned encode sits closer to the reference level (bass clarinet: reference 14.92 dB, stock +0.37, tuned +0.10).

Caveat stated plainly: one listener, four pairs, p = 0.0625 under pure guessing. Suggestive, not conclusive — more ears would settle it, which is part of why I'm posting rather than sitting on it.

The four constants were tuned on this corpus and the optima are broad. Unit tests pass (22/22).
