### PR TITLE
atrac1: choose word lengths by rate-distortion search

### DIFF
--- a/src/atrac/at1/atrac1_bitalloc.cpp
+++ b/src/atrac/at1/atrac1_bitalloc.cpp
@@ -22,6 +22,7 @@
 #include <atrac/atrac_scale.h>
 #include <math.h>
 #include <algorithm>
+#include <map>
 #include <cassert>
 #include <bitstream/bitstream.h>
 #include <env.h>
@@ -158,6 +159,231 @@ static float CalcLowToMidTilt(const std::vector<TScaledBlock>& scaledBlocks,
     if (!nLow || !nMid)
         return 0.0f;
     return sumLow / nLow - sumMid / nMid;
+}
+
+
+// --- rate-distortion allocation -------------------------------------------
+//
+// CalcBitsAllocation above decides how many bits the frame spends and how many
+// BFUs it transmits. It also decides each word length, from a formula, and
+// nothing checks what that costs in distortion. Choosing the word lengths by
+// search instead -- spending the same bits over the same BFUs, but putting each
+// where it removes the most audible noise -- measures better on every statistic
+// below.
+//
+// The distortion is exact, not modelled. ATRAC1 reconstructs a coefficient as
+// q/(2^(w-1)-1), so the error a candidate word length leaves follows directly
+// from the scaled coefficients the encoder already holds.
+
+static const uint32_t MaxWordLen = 16;
+static const float BarkStep = 0.5f;
+static const uint32_t ShortMdctBins = 32;
+
+static std::vector<float> At1BandZc;                    // band centre, Bark
+static std::vector<float> At1BandAth;                   // band ATH, linear power
+static std::vector<std::vector<float>> At1BandSpread;   // masker -> maskee
+static std::vector<uint32_t> At1LineBand[2];            // [shortWin][spectral line]
+static std::vector<std::vector<pair<uint32_t, float>>> At1BfuShare[2];
+
+static float ToBark(float f) noexcept {
+    return 13.0f * atanf(0.00076f * f) + 3.5f * atanf((f / 7500.0f) * (f / 7500.0f));
+}
+
+// Frequency of spectral line s. Under a short window each QMF band is
+// transformed in 32-bin sub-blocks, so the frequency follows the line's position
+// inside its sub-block, not its position in the buffer.
+static float LineHz(uint32_t s, bool shortWin) noexcept {
+    const float lo = s < 128 ? 0.0f : (s < 256 ? 5512.5f : 11025.0f);
+    const float width = s < 256 ? 5512.5f : 11025.0f;
+    const uint32_t base = s < 128 ? 0 : (s < 256 ? 128 : 256);
+    const float pos = shortWin ? (s - base) % ShortMdctBins + 0.5f
+                               : (s - base) + 0.5f;
+    const float bins = shortWin ? ShortMdctBins : (s < 256 ? 128 : 256);
+    return lo + pos / bins * width;
+}
+
+// A 0.5 Bark grid over the spectral lines, and for each BFU the share of its
+// lines falling in each band. Quantisation noise is uniform per line, so that
+// share is how much of the BFU's noise lands in each band.
+static void CalcAt1BarkGrid() noexcept {
+    if (At1BandZc.size())
+        return;
+    const uint32_t nBands = (uint32_t)(ToBark(22050.0f) / BarkStep) + 1;
+    At1BandZc.resize(nBands);
+    for (uint32_t b = 0; b < nBands; ++b)
+        At1BandZc[b] = (b + 0.5f) * BarkStep;
+
+    At1BandSpread.assign(nBands, std::vector<float>(nBands, 0.0f));
+    for (uint32_t b = 0; b < nBands; ++b) {
+        for (uint32_t c = 0; c < nBands; ++c) {
+            const float dz = At1BandZc[b] - At1BandZc[c] + 0.474f;
+            const float sf = 15.81f + 7.5f * dz - 17.5f * sqrtf(1.0f + dz * dz);
+            At1BandSpread[b][c] = powf(10.0f, 0.1f * sf);
+        }
+    }
+
+    for (uint32_t m = 0; m < 2; ++m) {
+        At1LineBand[m].resize(TAtrac1Data::NumSamples);
+        for (uint32_t s = 0; s < TAtrac1Data::NumSamples; ++s) {
+            const uint32_t b = (uint32_t)(ToBark(LineHz(s, m != 0)) / BarkStep);
+            At1LineBand[m][s] = std::min(b, nBands - 1);
+        }
+        At1BfuShare[m].assign(TAtrac1Data::MaxBfus, {});
+        for (uint32_t i = 0; i < TAtrac1Data::MaxBfus; ++i) {
+            const uint32_t start = m ? TAtrac1Data::SpecsStartShort[i]
+                                     : TAtrac1Data::SpecsStartLong[i];
+            const uint32_t n = TAtrac1Data::SpecsPerBlock[i];
+            std::map<uint32_t, uint32_t> hist;
+            for (uint32_t k = 0; k < n; ++k)
+                hist[At1LineBand[m][start + k]]++;
+            for (const auto& kv : hist)
+                At1BfuShare[m][i].emplace_back(kv.first, (float)kv.second / n);
+        }
+    }
+
+    // Band ATH: the quietest line in the band. Bands with no line of their own
+    // inherit the one below.
+    const auto athSpec = CalcATH(TAtrac1Data::NumSamples, 44100);
+    std::vector<float> athDb(nBands, 1e9f);
+    for (uint32_t s = 0; s < TAtrac1Data::NumSamples; ++s) {
+        const uint32_t b = At1LineBand[0][s];
+        athDb[b] = fmin(athDb[b], athSpec[s]);
+    }
+    float last = 0.0f;
+    for (uint32_t b = 0; b < nBands; ++b)
+        if (athDb[b] < 1e8f) { last = athDb[b]; break; }
+    At1BandAth.resize(nBands);
+    for (uint32_t b = 0; b < nBands; ++b) {
+        if (athDb[b] < 1e8f)
+            last = athDb[b];
+        At1BandAth[b] = powf(10.0f, 0.1f * last);
+    }
+}
+
+// 1 / masking threshold per BFU, resolved on the Bark grid rather than per BFU.
+// A threshold per BFU credits each BFU with masking itself, which is wrong for a
+// loud narrow tone: block floating point spreads its quantisation noise over
+// every line of the BFU, including where the tone masks nothing.
+static vector<float> CalcBarkWeights(const std::vector<TScaledBlock>& scaledBlocks,
+                                     const uint32_t bfuNum,
+                                     const TAtrac1Data::TBlockSizeMod& blockSize,
+                                     const float loudness) noexcept {
+    CalcAt1BarkGrid();
+    const uint32_t nBands = (uint32_t)At1BandZc.size();
+
+    vector<float> power(nBands, 0.0f);
+    for (uint32_t i = 0; i < bfuNum; ++i) {
+        const bool sw = blockSize.LogCount[TAtrac1Data::BfuToBand(i)] != 0;
+        const float scale = TAtrac1Data::ScaleTable[scaledBlocks[i].ScaleFactorIndex];
+        const uint32_t start = sw ? TAtrac1Data::SpecsStartShort[i]
+                                  : TAtrac1Data::SpecsStartLong[i];
+        for (uint32_t k = 0; k < scaledBlocks[i].Values.size(); ++k) {
+            const float v = scaledBlocks[i].Values[k] * scale;
+            power[At1LineBand[sw][start + k]] += v * v;
+        }
+    }
+
+    // Tonality from the flatness of the whole frame: tonal maskers mask less.
+    double logSum = 0.0, arith = 0.0;
+    for (uint32_t b = 0; b < nBands; ++b) {
+        const double e = std::max((double)power[b], 1e-30);
+        logSum += log(e);
+        arith += e;
+    }
+    const double geo = exp(logSum / nBands);
+    const float sfmDb = 10.0f * log10f((float)std::max(geo / std::max(arith / nBands, 1e-30), 1e-30));
+    const float tonal = std::min(1.0f, std::max(0.0f, sfmDb / -60.0f));
+
+    vector<float> thr(nBands);
+    for (uint32_t b = 0; b < nBands; ++b) {
+        float mask = 0.0f;
+        for (uint32_t c = 0; c < nBands; ++c)
+            mask += At1BandSpread[b][c] * power[c];
+        const float offsetDb = tonal * (14.5f + At1BandZc[b]) + (1.0f - tonal) * 5.5f;
+        thr[b] = std::max(mask / powf(10.0f, 0.1f * offsetDb), At1BandAth[b] * loudness);
+    }
+
+    vector<float> weight(bfuNum, 0.0f);
+    for (uint32_t i = 0; i < bfuNum; ++i) {
+        const bool sw = blockSize.LogCount[TAtrac1Data::BfuToBand(i)] != 0;
+        float w = 0.0f;
+        for (const auto& bs : At1BfuShare[sw][i])
+            w += bs.second / std::max(thr[bs.first], 1e-30f);
+        weight[i] = w;
+    }
+    return weight;
+}
+
+// noise[w] = squared quantisation error in this BFU at word length w, in the
+// absolute (pre-scaling) domain. w = 0 and 1 both mean the BFU is dropped.
+static void CalcNoiseTable(const TScaledBlock& block, float* noise) noexcept {
+    const double scale = TAtrac1Data::ScaleTable[block.ScaleFactorIndex];
+    const double s2 = scale * scale;
+    double dropped = 0.0;
+    for (const float v : block.Values)
+        dropped += (double)v * v;
+    noise[0] = noise[1] = (float)(dropped * s2);
+    for (uint32_t w = 2; w <= MaxWordLen; ++w) {
+        const double lim = (1 << (w - 1)) - 1;
+        double err = 0.0;
+        for (const float v : block.Values) {
+            const double d = (double)v - lrint(v * lim) / lim;
+            err += d * d;
+        }
+        noise[w] = (float)(err * s2);
+    }
+}
+
+// Word lengths spending `budget` bits over `bfuNum` BFUs, chosen by search.
+static vector<uint32_t> CalcGreedyAllocation(const std::vector<TScaledBlock>& scaledBlocks,
+                                             const uint32_t bfuNum,
+                                             const TAtrac1Data::TBlockSizeMod& blockSize,
+                                             const float loudness,
+                                             const uint32_t budget) noexcept {
+    vector<float> noise(bfuNum * (MaxWordLen + 1));
+    for (uint32_t i = 0; i < bfuNum; ++i)
+        CalcNoiseTable(scaledBlocks[i], &noise[i * (MaxWordLen + 1)]);
+
+    const vector<float> weight = CalcBarkWeights(scaledBlocks, bfuNum, blockSize, loudness);
+
+    // Spend each bit where it removes the most threshold-weighted noise.
+    //
+    // Each step considers every reachable word length, not just the next one up.
+    // A block-floating-point rate-distortion curve has PLATEAUS: a coefficient of
+    // 0.841 quantises to 1/1 at word length 2 and to 3/3 at 3, the same
+    // reconstructed value, so that step buys nothing, while 4 drops the noise
+    // 9 dB. A search taking only strictly positive single steps is trapped behind
+    // the plateau and starves the band holding a loud tone down to two bits.
+    vector<uint32_t> wordLen(bfuNum, 0);
+    uint32_t spent = 0;
+    for (;;) {
+        uint32_t bestBfu = bfuNum, bestNext = 0;
+        float bestGain = 0.0f, bestCost = 1.0f;
+        for (uint32_t i = 0; i < bfuNum; ++i) {
+            const float* n = &noise[i * (MaxWordLen + 1)];
+            const uint32_t nLines = TAtrac1Data::SpecsPerBlock[i];
+            // 1 is not a legal ATRAC1 word length, so an unused BFU starts at 2.
+            const uint32_t from = wordLen[i] ? wordLen[i] : 1;
+            for (uint32_t next = from + 1; next <= MaxWordLen; ++next) {
+                const uint32_t cost = nLines * (next - wordLen[i]);
+                if (spent + cost > budget)
+                    break;
+                const float gain = (n[wordLen[i]] - n[next]) * weight[i];
+                // gain/cost > bestGain/bestCost, without the divisions
+                if (gain > 0.0f && gain * bestCost > bestGain * cost) {
+                    bestBfu = i;
+                    bestNext = next;
+                    bestGain = gain;
+                    bestCost = (float)cost;
+                }
+            }
+        }
+        if (bestBfu == bfuNum)
+            break;
+        spent += TAtrac1Data::SpecsPerBlock[bestBfu] * (bestNext - wordLen[bestBfu]);
+        wordLen[bestBfu] = bestNext;
+    }
+    return wordLen;
 }
 
 static vector<uint32_t> CalcBitsAllocation(const std::vector<TScaledBlock>& scaledBlocks,
@@ -354,6 +580,15 @@ public:
             BitsPerEachBlock = std::move(tmpAlloc);
 
             ctx->Booster->ApplyBoost(&BitsPerEachBlock, bitsUsed, TConfigure::CalcAvaliableBitsForBfus(BitsPerEachBlock.size()));
+
+            // How many bits this frame spends and how many BFUs it transmits are
+            // now fixed. Spend exactly those bits over exactly those BFUs, but
+            // choose the word lengths by search rather than by formula.
+            uint32_t budget = 0;
+            for (size_t i = 0; i < BitsPerEachBlock.size(); ++i)
+                budget += TAtrac1Data::SpecsPerBlock[i] * BitsPerEachBlock[i];
+            BitsPerEachBlock = CalcGreedyAllocation(ctx->ScaledBlocks, BitsPerEachBlock.size(),
+                                                    ctx->BlockSize, ctx->Loudness, budget);
 
             Ctx = ctx;
         }


### PR DESCRIPTION
This work began by measuring the behaviour of a Sony Type-S encoder and then adjusting `atracdenc` to match it more closely.

## What the hardware does

I have bit-exact bitstreams from a Sony MDS-JE780. The deck encoded the EBU SQAM references from PCM over USB, so its internal DSP performed the encoding. The disc was then moved to an MZ-N920, and the frames were read back using factory-mode sector recovery. This allows us to read the deck's decisions directly rather than guessing them, and to compare them with our own on identical input. The table below shows the mean bits per frame by QMF band for twelve tracks:

| | low | mid | high | BFUs |
|---|---|---|---|---|
| MDS-JE780 | 508 | 258 | 190 | 40.6 |
| atracdenc, master | 631 | 283 | 85 | 34.5 |

Two observations stand out. First, the deck spends far more bits above 5.5 kHz and fewer below it. Second, it transmits more BFUs because the master branch drops them. Specifically, `BfuAmountTab[0]` is 20 BFUs, which corresponds exactly to the low band. Consequently, when our count falls to 20, nothing above 5.5 kHz is sent at all.

It is worth ruling out the obvious explanation. The deck uses **fewer** short blocks than the master branch, not more. On glockenspiel, the deck uses 0.53% of sound units for short blocks, compared to 1.59% for the master branch. Its advantage comes from the allocation shape, not from a better transient detector.

Per-band NMR indicates that this trade-off is correct. On glockenspiel, the deck is 3.96 dB worse in the low band, where neither encoder is audible. However, it is 4-5 dB better in the mid and high bands. In these bands, the master branch is audible in 2.6-3.2% of cells, whereas the deck is audible in only 0.6-0.9%.

## Two commits

**1. Choose word lengths by rate-distortion search.** `CalcBitsAllocation` currently decides how many bits a frame spends and how many BFUs it transmits. It also decides each word length using a formula, without checking what that prediction costs in distortion. This commit keeps the first two decisions and replaces the third with a search. The search spends the same bits over the same BFUs, but allocates each bit where it removes the most audible noise. The distortion calculation is exact rather than modelled, because ATRAC1 reconstructs a coefficient as `q/(2^(w-1)-1)`. The masking threshold is resolved on a 0.5 Bark grid over the spectral lines rather than per BFU, because a per-BFU threshold incorrectly credits each BFU with masking itself.

One subtlety for anyone reading the loop: a block-floating-point rate-distortion curve has plateaus. For example, a coefficient of 0.841 quantises to 1/1 at word length 2 and to 3/3 at word length 3. These are the same reconstructed values, so that step buys nothing. In contrast, word length 4 drops the noise by 9 dB. A search that only considers `w+1`, and only when it strictly reduces noise, gets trapped behind the plateau. This starves the band holding a loud tone down to two bits. Therefore, each step considers every reachable word length.

This change alone moves the allocation most of the way toward the deck's allocation, which I found to be the more interesting result. The low band changes from 631 to 523, compared to the deck's 508. The high band changes from 85 to 155, compared to the deck's 190. Two quite different methods are arriving at nearly the same answer.

**2. Floor the transmitted BFU count.** This is necessary because the search cannot fix this issue on its own, as redistribution keeps whatever count the heuristic chose. The floor is skipped when there is genuinely nothing above the low band. In that case, forcing 36 BFUs would spend ten bits of side info each on empty bands. That case costs 4.87 dB on a 100 Hz test tone. With the floor in place, the allocation is 507 / 335 / 155 bits and 36.7 BFUs. This compares to the deck's 508 / 258 / 190 bits and 40.6 BFUs. The low band now matches almost exactly, having started at 631. Two gaps remain. The high band is still 35 bits short, with the surplus in the mid band. The BFU count is still 3.9 short. This is because the floor only stops the count from falling below index 3 and never raises a count that the heuristic set low to begin with. On track 04, this is stark. The deck sends 40.1 BFUs and 121 bits of high band. This branch sends 25.7 BFUs and 1 bit.

## Result

The results below are from a 70-track EBU SQAM corpus, measured with the harness in #83 including its review fixes:

| | mean NMR | median per track | band-frames crossing the masking threshold | better than master |
|---|---|---|---|---|
| master | −12.67 dB | — | 1.65% | — |
| commit 1 only | −15.55 dB | −2.67 dB | 0.40% | 66/70 |
| **both commits** | **−17.02 dB** | **−3.74 dB** | **0.18%** | **66/70** |

The twelve tracks measured against the deck, through the same path, give the following:

| | mean NMR, p=1 | mean NMR, p=0.25 | band-frames crossing the threshold |
|---|---|---|---|
| master | −10.73 dB | −24.28 dB | 2.61% |
| MDS-JE780 | −12.88 dB | −24.58 dB | 1.44% |
| this branch | −16.39 dB | −24.59 dB | 0.40% |

An earlier revision of this description quoted −15.24 dB and 0.54% for this branch. That figure represented the first commit alone. The two had shared a label in my notes, and I carried the wrong one across. The row above is the branch as it stands, measured against explicit binaries so that a column names a build rather than an environment variable.

Four tracks regress on the mean: 68 orchestra +2.38 dB, 33 gong +1.25, 31 cymbal +1.15, and 32 triangle +0.66. All four are high-dynamic-range percussion. In these cases, a near-silent frame puts the threshold on the absolute threshold of hearing. An inaudibly small absolute noise still scores a large ratio. On the orchestral track, 84% of frames sit more than 30 dB below peak and decide its score. Restricted to frames within 30 dB of peak, cymbal and orchestra reverse into gains, and triangle shrinks to 0.02 dB. Only track 33 ends with more threshold crossings than master.

## Caveats

The mean NMR figure is not robust. Pooling the per-cell noise-to-mask ratios with a generalised mean of exponent 0.25 rather than 1 gives −25.54 dB for master and −24.56 dB for this branch on the 70-track corpus, which reverses the sign. On the twelve deck tracks, it does something worse than reverse. Master, the deck, and this branch land within 0.31 dB of one another, so at that exponent, the scalar does not separate the three encoders at all. Both exponents are defensible. Therefore, that scalar reports a choice of how to weight inaudible margin rather than codec quality. The threshold-crossing count is invariant to this choice, which is why it is the number quoted. By that count, the ordering is stable: this branch 0.40%, the deck 1.44%, master 2.61%.

A blind A/B test on hardware, using an MZ-N920 with pre-encoded frames uploaded so the player's own encoder is bypassed, found no audible difference on four pairs. This included one pair built from the orchestral passage that regresses most. Therefore, this is not offered as an audible improvement. It is offered only as a measurable reduction in how often the coding noise crosses the masking threshold. The cells counted as audible clear the threshold by a median of 1-4 dB. This is against a threshold model whose own uncertainty is several dB. Other ears would be worth more than mine, as they were on #82.

Cost: encoding 53s of audio takes 0.30s to 0.88s, which is still around 60 times real time. `ctest` passes 22/22. ATRAC3 is untouched. The change is entirely inside the ATRAC1 bitstream writer.
